### PR TITLE
fix: node env in pages/layout.js

### DIFF
--- a/app/(pages)/layout.js
+++ b/app/(pages)/layout.js
@@ -20,7 +20,7 @@ const GA_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS || false
 
 export const metadata = {
   metadataBase:
-    process.env.NODE_ENV === 'dev'
+    process.env.NODE_ENV === 'development'
       ? new URL(`http://localhost:${process.env.PORT || 3000}`)
       : new URL(APP_BASE_URL),
   applicationName: APP_NAME,


### PR DESCRIPTION
Right now, the repo is broken. When you try to run `next dev` it breaks because the NODE_ENV check is wrong. 
I just updated to start checking the right value.

**Before:**
<img width="1728" alt="image" src="https://github.com/darkroomengineering/satus/assets/26409015/ab48741d-a76d-44d0-9d66-e4925afbfaca">


**After:**
<img width="1728" alt="image" src="https://github.com/darkroomengineering/satus/assets/26409015/20c365bb-8f8a-4d1b-9204-23f66628b5a1">
