### PR TITLE
Fix undefined colors

### DIFF
--- a/components/dropdown/dropdown.module.css
+++ b/components/dropdown/dropdown.module.css
@@ -10,8 +10,8 @@
     padding: mobile-vw(8px) mobile-vw(12px);
     border-radius: mobile-vw(2px);
     border: 1px solid currentColor;
-    background-color: var(--theme-primary);
-    color: var(--theme-secondary);
+    background-color: var(--color-primary);
+    color: var(--color-secondary);
 
     @media (--desktop) {
       padding: desktop-vw(8px) desktop-vw(12px);
@@ -27,8 +27,8 @@
     align-items: center;
     z-index: 1;
     min-width: 100%;
-    background-color: var(--theme-primary);
-    border: 1px solid var(--theme-secondary);
+    background-color: var(--color-primary);
+    border: 1px solid var(--color-secondary);
     border-radius: mobile-vw(2px);
     overflow: clip;
     padding: mobile-vw(4px);
@@ -40,7 +40,7 @@
     }
 
     .option {
-      color: var(--theme-secondary);
+      color: var(--color-secondary);
       padding: mobile-vw(8px) mobile-vw(12px);
       position: relative;
       text-align: center;
@@ -56,8 +56,8 @@
 
       @media (--hover) {
         &:hover {
-          background-color: var(--theme-contrast);
-          color: var(--theme-primary);
+          background-color: var(--color-contrast);
+          color: var(--color-primary);
         }
       }
     }

--- a/components/fold/fold.module.css
+++ b/components/fold/fold.module.css
@@ -7,7 +7,7 @@
         position: absolute;
         inset: 0;
         pointer-events: none;
-        background-color: var(--theme-primary);
+        background-color: var(--color-primary);
         opacity: var(--progress, 0);
       }
     }

--- a/components/scrollbar/scrollbar.module.css
+++ b/components/scrollbar/scrollbar.module.css
@@ -13,7 +13,7 @@
   .thumb {
     min-height: desktop-vw(80px);
     width: desktop-vw(8px);
-    background-color: var(--theme-contrast);
+    background-color: var(--color-contrast);
     position: absolute;
     right: 0;
     border-radius: 0;


### PR DESCRIPTION
This replaces undefined CSS custom properties with the proper defined ones.

I came across this issue with the size dropdown on the Shopify page.

<img width="1290" alt="Screenshot 2025-06-14 at 11 56 59 PM" src="https://github.com/user-attachments/assets/590b9076-6e65-4367-a088-196e3d25d646" />

**Before**

<img width="187" alt="Screenshot 2025-06-14 at 11 56 09 PM" src="https://github.com/user-attachments/assets/f68d3937-c3a0-4de0-8cb6-fb56d884c738" />

**After**

<img width="188" alt="Screenshot 2025-06-14 at 11 55 14 PM" src="https://github.com/user-attachments/assets/d75ddecf-5edc-4ae9-ae9b-81d14fdf54d2" />