### PR TITLE
Fix the webpack build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -95,59 +95,59 @@ const nextConfig: NextConfig = {
     ],
     formats: ['image/avif', 'image/webp'],
   },
-  // webpack: (config) => {
-  //   config.module.rules.push({
-  //     test: /\.svg$/,
-  //     use: [
-  //       {
-  //         loader: '@svgr/webpack',
-  //         options: {
-  //           memo: true,
-  //           dimensions: false,
-  //           svgoConfig: {
-  //             multipass: true,
-  //             plugins: [
-  //               'removeDimensions',
-  //               'removeOffCanvasPaths',
-  //               'reusePaths',
-  //               'removeElementsByAttr',
-  //               'removeStyleElement',
-  //               'removeScriptElement',
-  //               'prefixIds',
-  //               'cleanupIds',
-  //               {
-  //                 name: 'cleanupNumericValues',
-  //                 params: {
-  //                   floatPrecision: 1,
-  //                 },
-  //               },
-  //               {
-  //                 name: 'convertPathData',
-  //                 params: {
-  //                   floatPrecision: 1,
-  //                 },
-  //               },
-  //               {
-  //                 name: 'convertTransform',
-  //                 params: {
-  //                   floatPrecision: 1,
-  //                 },
-  //               },
-  //               {
-  //                 name: 'cleanupListOfValues',
-  //                 params: {
-  //                   floatPrecision: 1,
-  //                 },
-  //               },
-  //             ],
-  //           },
-  //         },
-  //       },
-  //     ],
-  //   })
+  webpack: (config) => {
+    config.module.rules.push({
+      test: /\.svg$/,
+      use: [
+        {
+          loader: '@svgr/webpack',
+          options: {
+            memo: true,
+            dimensions: false,
+            svgoConfig: {
+              multipass: true,
+              plugins: [
+                'removeDimensions',
+                'removeOffCanvasPaths',
+                'reusePaths',
+                'removeElementsByAttr',
+                'removeStyleElement',
+                'removeScriptElement',
+                'prefixIds',
+                'cleanupIds',
+                {
+                  name: 'cleanupNumericValues',
+                  params: {
+                    floatPrecision: 1,
+                  },
+                },
+                {
+                  name: 'convertPathData',
+                  params: {
+                    floatPrecision: 1,
+                  },
+                },
+                {
+                  name: 'convertTransform',
+                  params: {
+                    floatPrecision: 1,
+                  },
+                },
+                {
+                  name: 'cleanupListOfValues',
+                  params: {
+                    floatPrecision: 1,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    })
 
-  //   return config
-  // },
+    return config
+  },
   headers: async () => [
     {
       source: '/(.*)',


### PR DESCRIPTION
This fixes the webpack build (`bun wp:build`). It's currently broken — exits with code 1 because the `@svgr/webpack` loader was commented out https://github.com/darkroomengineering/satus/commit/42be475121f7bfb14df97c510afba826aeb20ae5. More specifically, webpack is choking on the `darkroom.svg` in `<Footer />`.

**Before**

![Screenshot 2025-06-15 at 8 43 32 PM](https://github.com/user-attachments/assets/22c5744d-749f-4b57-b290-593b784a9ab2)

**After**

![Screenshot 2025-06-15 at 8 43 01 PM](https://github.com/user-attachments/assets/109f4e2d-65bd-4ec6-80a2-de54219fa92e)