### PR TITLE
fix: make the prepare script safe in linked worktrees

### DIFF
--- a/lib/scripts/prepare.ts
+++ b/lib/scripts/prepare.ts
@@ -1,0 +1,40 @@
+/**
+ * `prepare` entry point — installs the lefthook git hooks.
+ *
+ * In a linked worktree (`git worktree add`), the repo config is shared with the
+ * main checkout and `core.hooksPath` already points at its `.git/hooks`, so the
+ * hooks apply here without installing anything — and `lefthook install` refuses
+ * to run against that path and fails the whole `bun install`. Skip it instead.
+ * Outside a git repo (exported archive, CI cache restore) there is nothing to
+ * install into, so that skips too.
+ */
+
+import { resolve } from 'node:path'
+
+const git = Bun.spawnSync([
+  'git',
+  'rev-parse',
+  '--absolute-git-dir',
+  '--git-common-dir',
+])
+
+if (git.exitCode !== 0) {
+  console.log('prepare: not a git repository, skipping lefthook install')
+  process.exit(0)
+}
+
+const [gitDir, commonDir] = git.stdout.toString().trim().split('\n')
+
+if (gitDir && commonDir && gitDir !== resolve(commonDir)) {
+  console.log(
+    'prepare: linked worktree, hooks are shared with the main checkout — skipping lefthook install'
+  )
+  process.exit(0)
+}
+
+const lefthook = Bun.spawnSync(['bunx', 'lefthook', 'install'], {
+  stdout: 'inherit',
+  stderr: 'inherit',
+})
+
+process.exit(lefthook.exitCode ?? 1)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "bun run setup:styles && next build",
     "start": "next start",
     "preview": "bun run build && next start",
-    "prepare": "lefthook install",
+    "prepare": "bun ./lib/scripts/prepare.ts",
     "check": "biome check && bun node_modules/typescript7/bin/tsc --noEmit && bun test && bun run manifest:check",
     "clean": "rm -rf .next node_modules/.cache",
     "lint": "biome lint --max-diagnostics=200",


### PR DESCRIPTION
## What this does
`bun install` currently fails in any git worktree of this repo, because the `prepare` script runs `lefthook install`, and lefthook refuses the `core.hooksPath` the shared repo config carries (it points at the main checkout's `.git/hooks`). Since hooks in that shared path already apply to every worktree, there was never anything to install there — `prepare` now detects a linked worktree and skips, so installs just work.

## Summary
- `prepare` moves from bare `lefthook install` to `lib/scripts/prepare.ts`
- Linked worktree (git-dir ≠ git-common-dir) → skip with a note
- No git repo at all → skip with a note
- Main checkout → runs `lefthook install` and preserves its exit code, so real hook failures still fail the install

## Test Plan
- [x] Main checkout: `bun ./lib/scripts/prepare.ts` → installs hooks, exit 0
- [x] Linked worktree (`satus-next-preview`): skips with message, exit 0
- [x] Non-git directory: skips with message, exit 0
- [x] `bun run check` → exit 0 (360 tests)