### PR TITLE
test(e2e): lock in instant navigation with instant() (#339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ latest tag; security fixes land on the latest release (see `SECURITY.md`).
 
 - `post-checkout` lefthook hook that clears `.next/types` + `.next/dev/types` on branch switches (git flag `1` only — file checkouts untouched, rebases skipped), killing the ghost `tsc` errors caused by the previous branch's generated route types. Types regenerate on the next dev/build.
 - Minimal Playwright E2E harness (`e2e/home.e2e.ts`) — smoke spec covering page render, zero console errors, and zero critical/serious a11y violations (via `@axe-core/playwright`). Run with `bun run test:e2e`. Specs use `.e2e.ts` extension so `bun test` ignores them. (#e2e)
+- Instant-navigation regression test (`e2e/instant-navigation.e2e.ts`) using `@next/playwright`'s `instant()` helper — wraps the 404 page's "Go Home" link click and asserts the home shell paints without waiting on the network, so a refactor that de-opts instant navigation (a `cookies()` read leaking into a shared layout, a moved Suspense boundary) fails CI instead of going unnoticed. (#339)
 - Storybook themed to match Satūs: stories render on the site palette through shared CSS tokens (edit the site, the catalogue follows), with a dark/light/red/evil theme toolbar and a branded manager. (#210)
 - Optional `/storybook` route that proxies to a standalone Storybook deployment, enabled per-environment via `NEXT_PUBLIC_STORYBOOK_URL` and force-disabled in Production. (#210)
 - One-click Deploy to Vercel button (README + in-app manual) and clearer domain-setup guidance. (#210)

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "@csstools/postcss-global-data": "^4.0.0",
         "@happy-dom/global-registrator": "^20.11.1",
         "@next/bundle-analyzer": "16.3.0",
+        "@next/playwright": "16.3.0",
         "@playwright/test": "1.62.0",
         "@sanity/vision": "^6.7.0",
         "@storybook/addon-mcp": "^0.7.0",
@@ -751,6 +752,8 @@
     "@next/bundle-analyzer": ["@next/bundle-analyzer@16.3.0", "", { "dependencies": { "webpack-bundle-analyzer": "4.10.1" } }, "sha512-o8OiXKIATcSC6kHm5BIEmaDEDTFUDhpy9POQIbzAQTlb8NWwFhEQheTLFSbyQXxH2ywhjZ/e8EUlbOjj2k22Yg=="],
 
     "@next/env": ["@next/env@16.3.0", "", {}, "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw=="],
+
+    "@next/playwright": ["@next/playwright@16.3.0", "", { "peerDependencies": { "@playwright/test": ">=1.0.0" }, "optionalPeers": ["@playwright/test"] }, "sha512-lYFQDfksErmwifriLvnuhywiTqKtC7faxbLQSO2cmsrfVJsXA0L3cV1IqsXu7lhA8bFOOAxyvNBTtYyzKdKDew=="],
 
     "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw=="],
 

--- a/e2e/instant-navigation.e2e.ts
+++ b/e2e/instant-navigation.e2e.ts
@@ -1,0 +1,31 @@
+import { instant } from '@next/playwright'
+import { expect, test } from '@playwright/test'
+
+/**
+ * Instant navigation is a starter default (#259): the 404 page's "Go Home"
+ * link is the one real internal navigation in the app, and its shell must
+ * paint immediately from the prefetch cache — no waiting on the network.
+ * `instant()` (Next 16.3, `@next/playwright`) enforces that by deferring any
+ * dynamic data until the wrapped callback returns, so a regression that
+ * de-opts the shell (e.g. a `cookies()` read leaking into a shared layout,
+ * or a Suspense boundary moved past the fold) fails this test instead of
+ * going unnoticed.
+ */
+
+test.describe('instant navigation', () => {
+  test('404 -> home shell paints instantly, without waiting on the network', async ({
+    page,
+  }) => {
+    await page.goto('/this-route-does-not-exist-e2e')
+
+    await expect(page.getByRole('heading', { name: '404' })).toBeVisible()
+
+    const goHome = page.getByRole('link', { name: /go home/i })
+
+    await instant(page, async () => {
+      await goHome.click()
+
+      await expect(page.getByRole('heading', { name: 'Satūs' })).toBeVisible()
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@csstools/postcss-global-data": "^4.0.0",
     "@happy-dom/global-registrator": "^20.11.1",
     "@next/bundle-analyzer": "16.3.0",
+    "@next/playwright": "16.3.0",
     "@playwright/test": "1.62.0",
     "@sanity/vision": "^6.7.0",
     "@storybook/addon-mcp": "^0.7.0",


### PR DESCRIPTION
## What this does
Adds a regression test for the instant-navigation default #259 turned on. A refactor that de-opts the shell (a \`cookies()\` read leaking into a shared layout, a moved Suspense boundary) currently slips through CI unnoticed; this test fails the moment the 404→home navigation stops painting its shell without network waits.

Closes #339.

## Summary
- \`@next/playwright@16.3.0\` devDep (exact pin, matching \`@playwright/test\`/\`@next/bundle-analyzer\` convention; \`playwright-core\` override untouched)
- \`e2e/instant-navigation.e2e.ts\`: 404 → "Go Home" click wrapped in \`instant()\`, asserts the home heading paints
- No wire-up needed: \`testMatch '**/*.e2e.ts'\` and the e2e job pick it up automatically
- No \`next.config.ts\` change: the \`exposeTestingApiInProductionBuild\` flag only gates server-side MPA document requests, client-side Link navigations work without it (verified against a real production build)

## Test Plan
- [x] Full e2e suite against \`bun run build && bun run start\` (the CI path): 6 passed
- [x] Teeth check: wrong heading → test fails, restored → green
- [x] \`bun run check\` → exit 0 (419 tests)