### PR TITLE
fix: address the copilot review findings on #350

### DIFF
--- a/.github/workflows/lighthouse-to-slack.yml
+++ b/.github/workflows/lighthouse-to-slack.yml
@@ -115,7 +115,7 @@ jobs:
           # audit the login page and report meaningless scores against it.
           # Skip loudly instead of reporting fake numbers.
           if [ -z "$VERCEL_AUTOMATION_BYPASS_SECRET" ]; then
-            echo "::warning title=Lighthouse audit skipped::VERCEL_AUTOMATION_BYPASS_SECRET secret is not set, and this preview is behind Vercel Deployment Protection. Auditing it would score the SSO login page, not the app. Add VERCEL_AUTOMATION_BYPASS_SECRET in Settings → Secrets → Actions (value from Vercel → Project Settings → Deployment Protection → Protection Bypass for Automation) to enable the audit."
+            echo "::warning title=Lighthouse audit skipped::VERCEL_AUTOMATION_BYPASS_SECRET secret is not set. If this preview is behind Vercel Deployment Protection (the default for most teams), auditing it would score the SSO login page, not the app — so the audit is skipped rather than risk reporting fake numbers. Add VERCEL_AUTOMATION_BYPASS_SECRET in Settings → Secrets → Actions (value from Vercel → Project Settings → Deployment Protection → Protection Bypass for Automation) to enable the audit."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/lib/scripts/check-assets.ts
+++ b/lib/scripts/check-assets.ts
@@ -259,7 +259,7 @@ async function main() {
     if (!dimensions) {
       offenses.push({
         path,
-        detail: `cannot verify width (${ext} has no parser here) — re-encode to png/jpeg/webp or raise the size threshold in lib/scripts/check-assets.ts`,
+        detail: `cannot verify width (${ext} has no parser here) — re-encode to png/jpeg/webp, or add a parser / exempt the extension in lib/scripts/check-assets.ts`,
       })
       continue
     }

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -27,13 +27,16 @@ describe('proxy.ts rate-limit wiring', () => {
     expect(existsSync(RATE_LIMIT_PATH)).toBe(true)
   })
 
+  // Read guarded by existsSync so a deleted proxy.ts fails these with the
+  // regex assertion (empty string, clear message) instead of an ENOENT throw.
+  const readProxy = () =>
+    existsSync(PROXY_PATH) ? Bun.file(PROXY_PATH).text() : Promise.resolve('')
+
   it('proxy.ts imports the rate-limit util — deleting/editing this out turns off API rate limiting silently', async () => {
-    const source = await Bun.file(PROXY_PATH).text()
-    expect(source).toMatch(/from ['"]@\/lib\/utils\/rate-limit['"]/)
+    expect(await readProxy()).toMatch(/from ['"]@\/lib\/utils\/rate-limit['"]/)
   })
 
   it('proxy.ts actually calls rateLimit(), not just imports it unused', async () => {
-    const source = await Bun.file(PROXY_PATH).text()
-    expect(source).toMatch(/\brateLimit\s*\(/)
+    expect(await readProxy()).toMatch(/\brateLimit\s*\(/)
   })
 })


### PR DESCRIPTION
## What this does
Three post-merge review comments on #350, all valid, all small:

- The Lighthouse skip warning claimed the preview *is* behind Deployment Protection when the step only knows the secret is missing — now phrased conditionally
- The unparseable-dimensions failure in \`check:assets\` suggested raising the *size* threshold, which can't fix a *width* check — now points at the real remedies
- The proxy tripwire threw ENOENT instead of a clean assertion when \`proxy.ts\` is actually deleted — reads are now guarded so the failure message stays on point

## Test Plan
- [x] \`bun test proxy.test.ts\` → 4 pass
- [x] \`bun run check\` → green (includes check:assets)