### PR TITLE
docs(readme): turn the starter comparison into a per-feature matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,20 +80,31 @@ When setup completes it removes its own machinery from the project (the setup sc
 
 Satus is built for one job: content-driven marketing and creative sites with real motion, a CMS, and sometimes a storefront. The usual alternatives are good at different jobs — here is where the lines actually are, checked against each project in August 2026.
 
-| Starter           | Built for                              | Next.js today                          | What it gives you that Satus doesn't                                                 |
-| ----------------- | -------------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------ |
-| `create-next-app` | a bare framework scaffold, no opinions | 16.3, `cacheComponents` off by default | nothing to unlearn — and nothing included: no CMS, tests, CI, or component library   |
-| `next-forge`      | SaaS products in a Turborepo           | 16.1                                   | auth, payments, database, and email wired end to end (Clerk, Stripe, Prisma, Resend) |
-| `create-t3-app`   | typesafe full-stack apps               | 15.5                                   | tRPC + ORM + auth scaffolding, and the largest community of the four                 |
-| `next-enterprise` | enterprise app platforms               | 15.5                                   | OpenTelemetry, Kubernetes health checks, CI bundle-size and performance tracking     |
-
-What none of them ship, and Satus does:
-
-- Next 16.3 with `cacheComponents` and instant navigations already on — opt-in everywhere else, including `create-next-app`
-- Bun as runtime and test runner, the oxc toolchain (`oxlint` + `oxfmt`), and a single TypeScript 7
-- Tailwind v4 and CSS Modules under an explicit cascade contract, so utility and module styles can't silently fight
-- Strippable integrations: `bun run setup:project` removes what you don't keep, and the enforced CSP recomposes itself from what's left
-- The creative-site stack — Lenis, GSAP, Tempus, optional WebGL — plus e2e tests asserting a11y and instant navigation, a Lighthouse workflow, and an asset-weight gate
+| Feature                                         | Satūs                             | `create-next-app` | `next-forge`   | `create-t3-app`          | `next-enterprise` |
+| ----------------------------------------------- | --------------------------------- | ----------------- | -------------- | ------------------------ | ----------------- |
+| Built for                                       | creative & marketing sites        | bare scaffold     | SaaS monorepo  | typesafe full-stack apps | enterprise apps   |
+| Next.js today                                   | 16.3                              | 16.3              | 16.1           | 15.5                     | 15.5              |
+| Instant navigations on (`cacheComponents`)      | ✓                                 | ✗ opt-in          | ✗              | ✗                        | ✗                 |
+| Bun runtime + test runner                       | ✓                                 | ✗                 | ✗              | ✗                        | ✗                 |
+| oxc toolchain (`oxlint` + `oxfmt`)              | ✓                                 | ✗                 | ✗              | ✗                        | ✗                 |
+| Tailwind + CSS Modules under a cascade contract | ✓                                 | ✗                 | ✗              | ✗                        | ✗                 |
+| Animation stack (Lenis, GSAP, Tempus)           | ✓                                 | ✗                 | ✗              | ✗                        | ✗                 |
+| WebGL module (React Three Fiber)                | ✓ opt-in                          | ✗                 | ✗              | ✗                        | ✗                 |
+| CMS integration                                 | ✓ Sanity                          | ✗                 | ✓              | ✗                        | ✗                 |
+| E-commerce storefront                           | ✓ Shopify                         | ✗                 | ✗              | ✗                        | ✗                 |
+| Auth                                            | ✗                                 | ✗                 | ✓ Clerk        | ✓                        | ✗                 |
+| Payments                                        | ✗                                 | ✗                 | ✓ Stripe       | ✗                        | ✗                 |
+| Database / ORM                                  | ✗                                 | ✗                 | ✓ Prisma       | ✓                        | ✗                 |
+| Turborepo monorepo                              | ✗                                 | ✗                 | ✓              | ✗                        | ✗                 |
+| Pick your pieces                                | ✓ strip after clone               | ✗                 | ✗              | ✓ choose at init         | ✗                 |
+| Unit tests                                      | ✓ `bun test`                      | ✗                 | ✓ Vitest       | ✗                        | ✓ Vitest          |
+| E2E tests (Playwright)                          | ✓ with a11y + instant-nav asserts | ✗                 | ✗              | ✗                        | ✓                 |
+| Storybook                                       | ✓                                 | ✗                 | ✓              | ✗                        | ✓                 |
+| CI quality gates                                | ✓                                 | ✗                 | ✗ release only | ✗                        | ✓                 |
+| Performance budgets in CI                       | ✓ Lighthouse + asset weight       | ✗                 | ✗              | ✗                        | ✓ bundle size     |
+| Security headers + rate limiting                | ✓ enforced CSP, composed          | ✗                 | ✓ Arcjet       | ✗                        | ✗                 |
+| Observability wired                             | ✗                                 | ✗                 | ✓              | ✗                        | ✓ OpenTelemetry   |
+| Agent-ready docs                                | ✓ AGENTS.md + llms.txt + manifest | ✓ AGENTS.md       | ✗              | ✗                        | ✗                 |
 
 Pick something else when the job is different: `next-forge` for a SaaS with billing, `create-t3-app` when the product is a typesafe API-heavy app, `next-enterprise` when the org runs Kubernetes and wants observability from day one. For a content site that has to move well and ship fast, this is the shorter path.
 


### PR DESCRIPTION
## What this does
Replaces #353's prose-leaning table with a per-feature matrix: columns are starters, rows are features, ✓/✗ per cell with a short annotation only where a bare mark would mislead. Satūs takes honest ✗s on auth, payments, database, monorepo, and observability — that's what makes its ✓ column credible.

Three cells were re-verified against the repos before shipping (next-forge has cms + observability packages, its CI is release-only, t3's template ships no test runner).

## Test Plan
- [x] `bun run check` green
- [x] Every cell traceable to the August 2026 research or today's direct repo checks