### PR TITLE
fix: keep the literal agent-block marker out of AGENTS.md prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This is the **single source of truth** for engineering standards in this repo. Claude Code, Cursor, and all other AI tools read this file. The other docs (`CLAUDE.md`, `.cursor/rules/`) are thin pointers back here.
 
-This file changes only by deliberate review. `next dev` appends a managed `<!-- BEGIN:nextjs-agent-rules -->` block here when it detects an AI coding agent (no config opt-out exists) — revert that block on sight, never commit it.
+This file changes only by deliberate review. `next dev` appends a managed block here (an HTML comment fencing `nextjs-agent-rules`) when it detects an AI coding agent; there is no config opt-out. Revert that block on sight, never commit it. This sentence must never contain the block's literal opening marker: Next locates the block by searching for that exact string, and a prose match makes the next `next dev` run truncate everything below it.
 
 ---
 

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -48,7 +48,7 @@ const STEPS: Step[] = [
         <p className={s.text}>
           Point the site at your domain: copy{' '}
           <code className={s.inline}>.env.example</code> to{' '}
-          <code className={s.inline}>.env</code> and set{' '}
+          <code className={s.inline}>.env.local</code> and set{' '}
           <code className={s.inline}>NEXT_PUBLIC_BASE_URL</code>.
         </p>
         <p className={s.text}>


### PR DESCRIPTION
## What this does
Stops \`bun dev\` from silently destroying AGENTS.md. Next locates its managed agent-rules block by searching for the exact literal opening marker; the warning sentence at the top of AGENTS.md contained that literal as prose, so on the second dev run the finder matched the sentence instead of the real block and truncated everything below it — 553 lines to 13, no warning, exit 0. Found by the process audit's onboarding walker (P-A1, CRITICAL); first-hand corrupted evidence preserved in its throwaway clone.

The sentence now describes the marker without containing it, and states the constraint inline so it can't be reintroduced by a well-meaning edit. Also fixes the in-app manual's prose saying \`.env\` where its own code sample says \`.env.local\` (P-A3, independently confirmed by the state-machine walker).

## Verification
- Mechanism-verified: \`grep\` for the literal marker now hits zero prose occurrences repo-wide (only historical audit snapshots, which Next never reads) — the finder can only ever match its own genuine block
- Deterministic probe: with a genuine managed block planted, a dev run leaves the 553 lines above it untouched
- The full two-run truncation repro fires only under real agent-detection conditions (reproduced by the audit walker, not reproducible in the verification shell) — the mechanism proof above does not depend on it
- \`bun run check\` green

## Test Plan
- [x] \`bun run check\` → green
- [x] Zero literal-marker occurrences outside docs/audits history