### PR TITLE
fix(api): return 400, not 500, for malformed revalidate webhook bodies

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -66,6 +66,15 @@ export async function POST(request: NextRequest) {
       now: Date.now(),
     })
   } catch (error) {
+    // next-sanity's parseBody() runs `JSON.parse` on the raw request body
+    // after signature validation; malformed JSON throws a SyntaxError here.
+    // That's a client-input problem, not a server fault, so it gets a 400
+    // instead of feeding 5xx-triggered retries/alarms.
+    if (error instanceof SyntaxError) {
+      console.warn('Revalidation client error: invalid JSON body', error)
+      return new Response('Invalid JSON body', { status: 400 })
+    }
+
     console.error('Revalidation error:', error)
     return new Response('Internal Server Error', { status: 500 })
   }


### PR DESCRIPTION
## What this does
A malformed JSON body on the revalidate webhook returned 500, which webhook senders retry forever and monitoring treats as an outage. It's the client's fault, so it's now a 400 with a plain \`Invalid JSON body\` response. Process-audit finding P-D1.

Anchored on \`instanceof SyntaxError\` after tracing the actual throw sites: \`next-sanity\`'s \`parseBody\` lets \`JSON.parse\`'s SyntaxError propagate, while signature failures resolve \`false\` internally and never throw — so the 401 path was never at risk of misclassification.

## Test Plan
- [x] Malformed JSON + signature headers → 400 \`Invalid JSON body\`
- [x] Wrong signature + valid JSON → 401 unchanged
- [x] No secret configured → 503 unchanged
- [x] \`bun run check\` → 432 pass