### PR TITLE
fix(scripts): drop the sanity bundle's stale barrel-export entry

### DIFF
--- a/lib/scripts/integration-bundles.ts
+++ b/lib/scripts/integration-bundles.ts
@@ -125,9 +125,10 @@ export const INTEGRATION_BUNDLES = defineBundles({
       'SANITY_STUDIO_PROJECT_ID',
       'SANITY_REVALIDATE_SECRET',
     ],
-    barrelExports: [
-      { file: 'components/ui/index.ts', pattern: 'sanity-image' },
-    ],
+    // components/ui has no barrel file — components/ui/sanity-image is
+    // imported directly (see lib/integrations/sanity/components/rich-text.tsx),
+    // so there is no export line to restore on `satus add sanity`.
+    barrelExports: [],
     codeTransforms: [
       {
         file: 'app/(site)/layout.tsx',


### PR DESCRIPTION
## What this does
Every \`setup:project --keep sanity\` run printed \`Payload source has no barrel file components/ui/index.ts — skipping export restore\`, because the bundle referenced a barrel deleted long ago. The entry is config drift, not a missing feature: \`sanity-image\` is imported directly and there is no export line to restore. Process-audit finding P-B5. The barrel machinery itself stays — webgl's \`lib/hooks/index.ts\` entry is real and verified.

## Test Plan
- [x] \`bun run test:setup\` → 75 pass; full lib/scripts suite 147 pass
- [x] Dry-run \`--keep sanity\` in a throwaway copy: warning gone
- [x] \`bun run check\` → 432 pass