### PR TITLE
fix(scripts): flip partialPrefetching off with the cache-components opt-out

### DIFF
--- a/lib/scripts/setup-project.test.ts
+++ b/lib/scripts/setup-project.test.ts
@@ -1080,6 +1080,7 @@ describe('shouldDisableCacheComponents', () => {
 describe('CACHE_COMPONENTS_DISABLE_TRANSFORM (production ops applied to a next.config-shaped fixture)', () => {
   const nextConfigFixture = `const nextConfig: NextConfig = {
   cacheComponents: true,
+  partialPrefetching: true,
   experimental: {
     taint: true,
     cachedNavigations: true,
@@ -1090,7 +1091,7 @@ describe('CACHE_COMPONENTS_DISABLE_TRANSFORM (production ops applied to a next.c
 export default nextConfig
 `
 
-  it('flips cacheComponents and experimental.cachedNavigations to false, leaving other flags untouched', () => {
+  it('flips cacheComponents, partialPrefetching, and experimental.cachedNavigations to false, leaving other flags untouched', () => {
     const result = applyOpsToText(
       nextConfigFixture,
       CACHE_COMPONENTS_DISABLE_TRANSFORM.ops
@@ -1098,6 +1099,8 @@ export default nextConfig
 
     expect(result).toContain('cacheComponents: false')
     expect(result).not.toContain('cacheComponents: true')
+    expect(result).toContain('partialPrefetching: false')
+    expect(result).not.toContain('partialPrefetching: true')
     expect(result).toContain('cachedNavigations: false')
     // Probed separately as not requiring cacheComponents — left untouched.
     expect(result).toContain('prefetchInlining: true')
@@ -1122,6 +1125,7 @@ describe('isCacheComponentsDisabled (docs-vs-config consistency guard)', () => {
   it('is true after the production transform runs', () => {
     const nextConfigFixture = `const nextConfig: NextConfig = {
   cacheComponents: true,
+  partialPrefetching: true,
   experimental: { cachedNavigations: true },
 }
 `
@@ -1130,6 +1134,7 @@ describe('isCacheComponentsDisabled (docs-vs-config consistency guard)', () => {
       CACHE_COMPONENTS_DISABLE_TRANSFORM.ops
     )
     expect(isCacheComponentsDisabled(flipped)).toBe(true)
+    expect(flipped).toContain('partialPrefetching: false')
   })
 
   it('is true for hand-edited spacing variants', () => {

--- a/lib/scripts/setup-project.ts
+++ b/lib/scripts/setup-project.ts
@@ -657,12 +657,12 @@ export const shouldDisableCacheComponents = (
 /**
  * next.config.ts transform that flips Cache Components off.
  *
- * Both ops are required together: an empirical `bun run build` probe showed
- * `experimental.cachedNavigations: true` hard-errors Next's config
- * validation when `cacheComponents` is false ("`experimental.cachedNavigations`
- * requires `cacheComponents` to be enabled."). `experimental.prefetchInlining`
- * was probed too and needs no change — Next's config validation accepts it
- * fine with `cacheComponents` off.
+ * All three ops are required together: Next's config validation rejects
+ * `cacheComponents: false` combined with either `partialPrefetching: true`
+ * ("`partialPrefetching` requires `cacheComponents` to be enabled.") or
+ * `experimental.cachedNavigations: true` ("`experimental.cachedNavigations`
+ * requires `cacheComponents` to be enabled.") — both depend on Cache
+ * Components and must be flipped off in the same pass.
  */
 export const CACHE_COMPONENTS_DISABLE_TRANSFORM: CodeTransform = {
   file: 'next.config.ts',
@@ -671,6 +671,12 @@ export const CACHE_COMPONENTS_DISABLE_TRANSFORM: CodeTransform = {
       kind: 'setObjectProperty',
       variableName: 'nextConfig',
       propertyPath: 'cacheComponents',
+      valueText: 'false',
+    },
+    {
+      kind: 'setObjectProperty',
+      variableName: 'nextConfig',
+      propertyPath: 'partialPrefetching',
       valueText: 'false',
     },
     {


### PR DESCRIPTION
## What this does
\`setup:project --preset blank\` (and any no-CMS/no-storefront keep-set) produced a project that fails to build: the opt-out transform flipped \`cacheComponents\` and \`cachedNavigations\` to false but left the new top-level \`partialPrefetching: true\`, which Next 16.3's validation rejects without cacheComponents. All three now flip together, and the transform's docstring states the actual constraint. Process-audit finding P-B1 (High).

Verified against the literal repro: blank-preset setup in a patched clone → \`bun install\` → build no longer errors on the flag combination.

**Known and out of scope here**: with this crash gone, the blank build surfaces a deeper pruning gap — files like \`lib/seo/routes.ts\` statically import sanity modules the strip removes (P-B7, fix in flight separately).

## Test Plan
- [x] \`bun run test:setup\` → 75 pass with new partialPrefetching assertions
- [x] Blank-preset repro: config-validation error gone
- [x] \`bun run check\` → 432 pass