### PR TITLE
docs: document handoff's flags (SM-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ bun run build        # Production build
 bun storybook        # Component catalogue
 bun run check        # lint + format + types + tests + asset budget (run before pushing)
 bun run setup:project  # Strip integrations you don't need
-bun run handoff      # Client delivery: strips branding, swaps in PROD-README, generates inventory
+bun run handoff      # Client delivery: strips branding, swaps in PROD-README, generates inventory (--dry-run, --force)
 ```
 
 The full list lives in `package.json`.


### PR DESCRIPTION
handoff's --dry-run and --force were discoverable only by reading the script; the README Scripts line now names them. --verbose/--help are parsed but unused, so they are deliberately not documented.

Process-audit docs finding. Test plan: oxfmt clean on touched files, link targets verified, full check green on the branch set.