### PR TITLE
docs: reconcile the two deploy stories (SM-2)

### DIFF
--- a/PROD-README.md
+++ b/PROD-README.md
@@ -45,7 +45,7 @@ Manual cache clear: `GET https://[domain]/api/revalidate`
 
 ## Deployment
 
-Push to `main` branch for Vercel deployment.
+Vercel deploys automatically on every push to `main`. If the project isn't linked yet, run `vercel link` once first (see Quick Start).
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The full list lives in `package.json`.
 vercel
 ```
 
+`vercel` (or the Deploy button above) links and deploys the project the first time. Once the project is linked, push to the tracked branch and Vercel deploys automatically — the CLI is only needed again for manual/preview deploys.
+
 **Optional GitHub Secrets** for the Lighthouse CI workflow: `VERCEL_TOKEN`
 (Vercel API token — the job skips gracefully with a warning when it's absent
 or invalid) and `VERCEL_AUTOMATION_BYPASS_SECRET` (needed when previews are


### PR DESCRIPTION
README said deploy via vercel CLI, PROD-README said push to main; each now states both truthfully: CLI or button links the first deploy, pushes deploy automatically once linked.

Process-audit docs finding. Test plan: oxfmt clean on touched files, link targets verified, full check green on the branch set.