### PR TITLE
docs: route readers to the CSP mechanism and the api README (P-routing)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,7 +423,7 @@ Critical rules:
 
 ### Next.js 16 Request Proxy
 
-`proxy.ts` at the project root handles cross-cutting request concerns — currently rate limiting for `/api/*` routes via `@/utils/rate-limit`. Security headers stay in `next.config.ts`.
+`proxy.ts` at the project root handles cross-cutting request concerns — currently rate limiting for `/api/*` routes via `@/utils/rate-limit`. Security headers stay in `next.config.ts`, composed from the integration registry's `cspSources` by `lib/integrations/csp.ts`, plus project origins via `PROJECT_CSP_EXTRA_SOURCES` — details in `SECURITY.md`.
 
 ### Error boundaries
 

--- a/README.md
+++ b/README.md
@@ -83,17 +83,19 @@ lib/                    # Everything non-UI
 
 ## Documentation
 
-| Area                  | Documentation                                                                    |
-| --------------------- | -------------------------------------------------------------------------------- |
-| Engineering Standards | [AGENTS.md](AGENTS.md) - Canonical rules for all AI tools and contributors       |
-| Architecture          | [ARCHITECTURE.md](ARCHITECTURE.md) - Key decisions, patterns, customization      |
-| Component Catalogue   | Storybook (`bun storybook`) - Isolated UI primitives with docs                   |
-| Component Inventory   | [COMPONENTS.md](COMPONENTS.md) - Auto-generated component/hook/utility manifest  |
-| Changelog             | [CHANGELOG.md](CHANGELOG.md) - Release history and versioning policy             |
-| App Router            | [app/README.md](app/README.md) - Pages, layouts, routing                         |
-| Components            | [components/README.md](components/README.md) - UI reference                      |
-| Library               | [lib/README.md](lib/README.md) - Hooks, utils, integrations                      |
-| Integrations          | [lib/integrations/README.md](lib/integrations/README.md) - Sanity, Shopify, etc. |
+| Area                  | Documentation                                                                          |
+| --------------------- | -------------------------------------------------------------------------------------- |
+| Engineering Standards | [AGENTS.md](AGENTS.md) - Canonical rules for all AI tools and contributors             |
+| Architecture          | [ARCHITECTURE.md](ARCHITECTURE.md) - Key decisions, patterns, customization            |
+| Security              | [SECURITY.md](SECURITY.md) - Security policy, CSP composition, vulnerability reporting |
+| Component Catalogue   | Storybook (`bun storybook`) - Isolated UI primitives with docs                         |
+| Component Inventory   | [COMPONENTS.md](COMPONENTS.md) - Auto-generated component/hook/utility manifest        |
+| Changelog             | [CHANGELOG.md](CHANGELOG.md) - Release history and versioning policy                   |
+| App Router            | [app/README.md](app/README.md) - Pages, layouts, routing                               |
+| API Routes            | [app/api/README.md](app/api/README.md) - Endpoint reference, webhook setup             |
+| Components            | [components/README.md](components/README.md) - UI reference                            |
+| Library               | [lib/README.md](lib/README.md) - Hooks, utils, integrations                            |
+| Integrations          | [lib/integrations/README.md](lib/integrations/README.md) - Sanity, Shopify, etc.       |
 
 ## Scripts
 

--- a/app/README.md
+++ b/app/README.md
@@ -26,6 +26,8 @@ The root layout stays a bare shell on purpose: anything added to it is a
 deliberate decision to ship it to `/studio` too. App-flavored concerns
 (providers, metadata, analytics) belong in `app/(site)/layout.tsx`.
 
+See [app/api/README.md](api/README.md) for the API surface (endpoints, webhook setup).
+
 ## Getting Started
 
 **Use the interactive setup:**


### PR DESCRIPTION
A fork owner asking how to change the CSP could not route there; README gains Security and API Routes doc-table rows, AGENTS.md's proxy note names cspSources/PROJECT_CSP_EXTRA_SOURCES, app/README links the orphaned api README.

Process-audit docs finding. Test plan: oxfmt clean on touched files, link targets verified, full check green on the branch set.