### PR TITLE
fix(scripts): generate emits valid, formatted code and refuses overwrites

### DIFF
--- a/lib/scripts/generate-component.test.ts
+++ b/lib/scripts/generate-component.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for lib/scripts/generate-component.ts's pure template builder.
+ *
+ * Run with: bun test lib/scripts/generate-component.test.ts
+ *
+ * Covers the P-C9 regression (generated imports must pass `oxfmt --check`'s
+ * import-grouping rule out of the box).
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+import { generateComponentContent } from './generate-component'
+
+describe('generateComponentContent — import grouping (P-C9)', () => {
+  it('separates the external (clsx/react) group from the sibling CSS import', () => {
+    const content = generateComponentContent('audit-widget', {
+      category: 'ui',
+    })
+    expect(content).toContain(
+      "import type { HTMLAttributes, ReactNode } from 'react'\n\nimport s from './audit-widget.module.css'"
+    )
+  })
+
+  it('keeps the blank line when the component is a client component', () => {
+    const content = generateComponentContent('audit-widget', {
+      category: 'ui',
+      client: true,
+    })
+    expect(content.startsWith("'use client'\n\n")).toBe(true)
+    expect(content).toContain(
+      "import type { HTMLAttributes, ReactNode } from 'react'\n\nimport s from './audit-widget.module.css'"
+    )
+  })
+
+  it('builds a valid PascalCase component name for a hyphenated component name', () => {
+    const content = generateComponentContent('audit-widget', {
+      category: 'ui',
+    })
+    expect(content).toContain('export function AuditWidget(')
+    expect(content).toContain('interface AuditWidgetProps')
+  })
+})

--- a/lib/scripts/generate-component.ts
+++ b/lib/scripts/generate-component.ts
@@ -13,6 +13,8 @@ import * as p from '@clack/prompts'
 import { findBarrelLine, insertBarrelLine } from './barrel-file'
 import {
   cancelGuard,
+  formatGeneratedFiles,
+  refuseIfExists,
   toCamelCase,
   toPascalCase,
   withSpinner,
@@ -99,7 +101,7 @@ export async function promptComponentConfig(): Promise<ComponentConfig> {
 /**
  * Generate component index.tsx content
  */
-function generateComponentContent(
+export function generateComponentContent(
   componentName: string,
   options: ComponentOptions
 ): string {
@@ -110,6 +112,7 @@ function generateComponentContent(
 
   return `${directive}import cn from 'clsx'
 import type { HTMLAttributes, ReactNode } from 'react'
+
 import s from './${componentName}.module.css'
 
 interface ${pascalName}Props extends HTMLAttributes<HTMLDivElement> {
@@ -230,6 +233,12 @@ export async function createComponent(
   }
 
   const componentDir = `components/${componentPath}`
+  const indexPath = `${componentDir}/index.tsx`
+  const cssPath = `${componentDir}/${componentName}.module.css`
+
+  // Refuse to clobber an existing component — re-running the generator with
+  // the same name must never silently overwrite hand-edited output.
+  await refuseIfExists([indexPath, cssPath])
 
   await withSpinner(
     `Generating component "${componentPath}"`,
@@ -243,10 +252,14 @@ export async function createComponent(
       const componentContent = generateComponentContent(componentName, options)
       const cssContent = generateCssContent(componentName)
 
-      await Bun.write(`${componentDir}/index.tsx`, componentContent)
-      await Bun.write(`${componentDir}/${componentName}.module.css`, cssContent)
+      await Bun.write(indexPath, componentContent)
+      await Bun.write(cssPath, cssContent)
     }
   )
+
+  // Keep generated output aligned with the repo's formatting gate, even if
+  // the templates above drift out of sync with oxfmt's import-grouping rules.
+  await formatGeneratedFiles([indexPath, cssPath])
 
   // Show what was created
   p.log.success(`Created files:`)

--- a/lib/scripts/generate-page.test.ts
+++ b/lib/scripts/generate-page.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for lib/scripts/generate-page.ts's pure template builder.
+ *
+ * Run with: bun test lib/scripts/generate-page.test.ts
+ *
+ * Covers the P-C8 regression (hyphenated page names must not break the
+ * generated identifier) and the P-C9 regression (generated imports must
+ * pass `oxfmt --check`'s import-grouping rule out of the box).
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+import { generatePageContent } from './generate-page'
+
+describe('generatePageContent — identifier safety (P-C8)', () => {
+  it('builds a valid PascalCase function name for a hyphenated page name', () => {
+    const content = generatePageContent('audit-page', {})
+    expect(content).toContain('export default function AuditPagePage()')
+    // The identifier itself must never contain the raw hyphen.
+    expect(content).not.toContain('function Audit-page')
+  })
+
+  it('builds a valid PascalCase function name for a multi-hyphen page name', () => {
+    const content = generatePageContent('my-cool-landing', {})
+    expect(content).toContain('export default function MyCoolLandingPage()')
+  })
+
+  it('keeps a single-word page name working as before', () => {
+    const content = generatePageContent('about', {})
+    expect(content).toContain('export default function AboutPage()')
+  })
+
+  it('uses the PascalCase name for the async sanity variant too', () => {
+    const content = generatePageContent('audit-page', { sanity: true })
+    expect(content).toContain('export default async function AuditPagePage()')
+  })
+
+  it('still uses human-readable display text for h1/metadata (not the identifier)', () => {
+    const content = generatePageContent('audit-page', {})
+    expect(content).toContain('<h1>Audit-page</h1>')
+    expect(content).toContain(`title: 'Audit-page'`)
+  })
+})
+
+describe('generatePageContent — import grouping (P-C9)', () => {
+  it('separates external and internal (@/) imports with a blank line', () => {
+    const content = generatePageContent('about', {})
+    expect(content).toContain(
+      "import type { Metadata } from 'next'\n\nimport { Wrapper } from '@/components/layout/wrapper'"
+    )
+  })
+
+  it('keeps the external sanity import out of the internal group', () => {
+    const content = generatePageContent('about', { sanity: true })
+    const importBlock = content.split('\n\n')[0]
+    // next-sanity/live is external; it must appear before the blank line
+    // that separates external imports from the @/-aliased internal group.
+    expect(importBlock).toContain(`from 'next-sanity/live'`)
+    expect(importBlock).not.toContain('@/')
+  })
+
+  it('keeps a single blank line between the external and internal groups regardless of options', () => {
+    const content = generatePageContent('about', {
+      sanity: true,
+      shopify: true,
+      webgl: true,
+      css: true,
+    })
+    const lines = content.split('\n')
+    const firstInternalIndex = lines.findIndex((line) =>
+      line.includes("from '@/")
+    )
+    expect(lines[firstInternalIndex - 1]).toBe('')
+  })
+})

--- a/lib/scripts/generate-page.ts
+++ b/lib/scripts/generate-page.ts
@@ -10,7 +10,13 @@
 
 import * as p from '@clack/prompts'
 
-import { cancelGuard, withSpinner } from './generate-shared'
+import {
+  cancelGuard,
+  formatGeneratedFiles,
+  refuseIfExists,
+  toPascalCase,
+  withSpinner,
+} from './generate-shared'
 import { getIntegrationEntries } from './integration-bundles'
 import { createDir } from './utils'
 
@@ -95,31 +101,42 @@ export async function promptPageConfig(): Promise<PageConfig> {
 /**
  * Generate page.tsx content
  */
-function generatePageContent(pageName: string, options: PageOptions): string {
+export function generatePageContent(
+  pageName: string,
+  options: PageOptions
+): string {
   const { webgl, sanity, shopify, theme = 'dark' } = options
+  // Display text (h1, metadata title/description) — the raw, human-facing
+  // name is fine here, hyphens and all.
   const title = pageName.charAt(0).toUpperCase() + pageName.slice(1)
+  // Identifier text (the exported function name) must be a valid PascalCase
+  // JS identifier — hyphens in `pageName` would otherwise break syntax.
+  const pascalName = toPascalCase(pageName)
 
-  const imports: string[] = [
-    `import type { Metadata } from 'next'`,
+  const externalImports: string[] = [`import type { Metadata } from 'next'`]
+  const internalImports: string[] = [
     `import { Wrapper } from '@/components/layout/wrapper'`,
   ]
   if (sanity || shopify) {
-    imports.push(
+    internalImports.push(
       `import { isConfigured } from '@/lib/integrations/registry'`,
       `import { NotConfigured } from '@/components/ui/not-configured'`
     )
   }
   if (sanity) {
-    imports.push(
-      `import { sanityFetch } from 'next-sanity/live'`,
+    externalImports.push(`import { sanityFetch } from 'next-sanity/live'`)
+    internalImports.push(
       `import { pageQuery } from '@/lib/integrations/sanity/queries'`,
       `import type { Page } from '@/lib/integrations/sanity/sanity.types'`,
       `import { generateSanityMetadata } from '@/lib/utils/metadata'`
     )
   }
   if (shopify) {
-    imports.push(`import { Cart } from '@/lib/integrations/shopify/cart'`)
+    internalImports.push(
+      `import { Cart } from '@/lib/integrations/shopify/cart'`
+    )
   }
+  const imports = [...externalImports, '', ...internalImports]
 
   const wrapperProps = [`theme="${theme}"`, ...(webgl ? ['webgl'] : [])].join(
     ' '
@@ -214,7 +231,7 @@ export const metadata: Metadata = {
   return `${imports.join('\n')}
 ${metadataExport}
 
-export default ${isAsync ? 'async ' : ''}function ${title}Page() {
+export default ${isAsync ? 'async ' : ''}function ${pascalName}Page() {
 ${body}
 }
 `
@@ -229,6 +246,15 @@ export async function createPage(
 ): Promise<void> {
   const pageDir = `app/${pageName}`
   const componentsDir = `${pageDir}/_components`
+  const pagePath = `${pageDir}/page.tsx`
+  const cssPath = `${pageDir}/${pageName}.module.css`
+
+  // Refuse to clobber an existing page — re-running the generator with the
+  // same name must never silently overwrite hand-edited output.
+  const targets = options.css ? [pagePath, cssPath] : [pagePath]
+  await refuseIfExists(targets)
+
+  const writtenPaths: string[] = []
 
   await withSpinner(
     `Creating page structure for "${pageName}"`,
@@ -246,7 +272,8 @@ export async function createPage(
 
       // Generate and write page.tsx
       const pageContent = generatePageContent(pageName, options)
-      await Bun.write(`${pageDir}/page.tsx`, pageContent)
+      await Bun.write(pagePath, pageContent)
+      writtenPaths.push(pagePath)
 
       // Create CSS module if requested
       if (options.css) {
@@ -256,10 +283,15 @@ export async function createPage(
   /* Add your styles here */
 }
 `
-        await Bun.write(`${pageDir}/${pageName}.module.css`, cssContent)
+        await Bun.write(cssPath, cssContent)
+        writtenPaths.push(cssPath)
       }
     }
   )
+
+  // Keep generated output aligned with the repo's formatting gate, even if
+  // the templates above drift out of sync with oxfmt's import-grouping rules.
+  await formatGeneratedFiles(writtenPaths)
 
   // Show what was created
   p.log.success(`Generated files:`)

--- a/lib/scripts/generate-shared.test.ts
+++ b/lib/scripts/generate-shared.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for lib/scripts/generate-shared.ts.
+ *
+ * Run with: bun test lib/scripts/generate-shared.test.ts
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { refuseIfExists, toCamelCase, toPascalCase } from './generate-shared'
+
+describe('toPascalCase', () => {
+  it('capitalizes a single word', () => {
+    expect(toPascalCase('button')).toBe('Button')
+  })
+
+  it('joins hyphenated words without the hyphen (identifier-safe)', () => {
+    expect(toPascalCase('audit-page')).toBe('AuditPage')
+    expect(toPascalCase('hero-section')).toBe('HeroSection')
+    expect(toPascalCase('animated-text')).toBe('AnimatedText')
+  })
+
+  it('handles multi-hyphen names', () => {
+    expect(toPascalCase('my-long-component-name')).toBe('MyLongComponentName')
+  })
+})
+
+describe('toCamelCase', () => {
+  it('lowercases the first word only', () => {
+    expect(toCamelCase('my-component')).toBe('myComponent')
+  })
+
+  it('handles a single word', () => {
+    expect(toCamelCase('button')).toBe('button')
+  })
+})
+
+describe('refuseIfExists', () => {
+  let dir: string
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  it('resolves without throwing when no target exists', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'generate-shared-test-'))
+    await expect(
+      refuseIfExists([join(dir, 'index.tsx'), join(dir, 'index.module.css')])
+    ).resolves.toBeUndefined()
+  })
+
+  it('throws naming the first existing path, before checking the rest', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'generate-shared-test-'))
+    const existing = join(dir, 'index.tsx')
+    await Bun.write(existing, 'existing content')
+
+    await expect(
+      refuseIfExists([existing, join(dir, 'index.module.css')])
+    ).rejects.toThrow(existing)
+  })
+})

--- a/lib/scripts/generate-shared.ts
+++ b/lib/scripts/generate-shared.ts
@@ -82,3 +82,57 @@ export async function withSpinner(
     throw error instanceof Error ? error : new Error(String(error))
   }
 }
+
+// ---------------------------------------------------------------------------
+// Overwrite guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Refuse to proceed if any of the given paths already exist on disk.
+ *
+ * Scaffolders must never silently overwrite hand-edited output. Throws
+ * before any file is written, naming the first existing path, so the
+ * caller's try/catch (see generate.ts) surfaces a clear message and exits
+ * non-zero with zero writes performed.
+ */
+export async function refuseIfExists(paths: string[]): Promise<void> {
+  for (const path of paths) {
+    if (await Bun.file(path).exists()) {
+      throw new Error(
+        `"${path}" already exists. Refusing to overwrite it — remove the file first or choose a different name.`
+      )
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Post-write formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Run oxfmt on freshly generated files so template drift can never regress
+ * the `oxfmt --check` gate that `bun run check` enforces.
+ *
+ * Best-effort: a formatting failure is surfaced as a warning, not thrown —
+ * a missing/broken oxfmt binary shouldn't block scaffolding.
+ */
+export async function formatGeneratedFiles(paths: string[]): Promise<void> {
+  if (paths.length === 0) return
+  try {
+    const proc = Bun.spawn(['bun', 'oxfmt', ...paths], {
+      stdout: 'ignore',
+      stderr: 'pipe',
+    })
+    const [exitCode, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stderr).text(),
+    ])
+    if (exitCode !== 0) {
+      p.log.warn(`oxfmt formatting failed: ${stderr.trim()}`)
+    }
+  } catch (error) {
+    p.log.warn(
+      `Could not run oxfmt on generated files: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}


### PR DESCRIPTION
## What this does
Three process-audit findings on \`bun run generate\`, all reproduced before fixing:

- **P-C8 (Critical)**: a hyphenated page name — permitted by the prompt's own validator — produced \`export default function Audit-pagePage()\`, a hard syntax error. Identifier positions now use the shared \`toPascalCase\`; display text keeps the human-readable title.
- **P-C9 (High)**: every generated file failed \`oxfmt --check\` (no blank line between external and internal import groups). Templates fixed, plus a best-effort oxfmt pass on just-written files as drift defense. Also fixed \`next-sanity/live\` being bucketed with internal imports.
- **P-C10 (High)**: re-running with an existing name silently overwrote all three files. Now refuses pre-write with the path named, exit 1 — verified byte-identical survivors via checksums.

18 new unit tests cover the naming, grouping, and refusal behaviors.

## Test Plan
- [x] Hyphenated page + component generate → parse and pass oxfmt untouched, \`check\` green with files present
- [x] Same-name re-run → refusal, exit 1, planted markers survive byte-identical
- [x] \`bun run check\` → 448 pass including the new tests