### PR TITLE
fix(scripts): handoff no longer ships a broken build

### DIFF
--- a/lib/scripts/prepare-handoff.ts
+++ b/lib/scripts/prepare-handoff.ts
@@ -24,6 +24,8 @@ import {
   integrations as registryIntegrations,
 } from '@/integrations/registry'
 
+import type { AstOperation } from './ast-operation-types'
+import { applyOpsToText } from './ast-transforms'
 import { isInstalled } from './bundle-installer'
 import { cancelGuard } from './generate-shared'
 import { getIntegrationEntries } from './integration-bundles'
@@ -134,6 +136,53 @@ interface HandoffOptions {
 }
 
 /**
+ * AST ops that drop the Darkroom credit link (logo + link to
+ * darkroom.engineering) from the footer, and its now-dangling Logo import.
+ */
+const FOOTER_LOGO_OPS: AstOperation[] = [
+  { kind: 'removeImport', specifier: '@/components/ui/darkroom.svg' },
+  {
+    kind: 'removeJsxElement',
+    tagName: 'Link',
+    attribute: { name: 'aria-label', value: 'Darkroom Engineering' },
+  },
+]
+
+/**
+ * Remove the Darkroom credit logo/link from the footer (cross-platform).
+ *
+ * `removeBrandingAssets` deletes `components/ui/darkroom.svg`, and the
+ * footer is the only place in the tree that imports it — leaving the import
+ * in place breaks `bun run build` with a "Module not found" error. This
+ * rewrites the footer via the AST transform engine to drop the Logo import
+ * and the credit link that renders it, then collapses the whitespace-only
+ * line the JSX removal leaves behind so the file stays `oxfmt`-clean.
+ * Idempotent: re-running over an already-cleaned footer is a no-op.
+ */
+const removeFooterLogo = async (dryRun: boolean): Promise<boolean> => {
+  try {
+    const footerPath = resolvePath('components/layout/footer/index.tsx')
+    if (!(await pathExists(footerPath))) return false
+
+    const original = await Bun.file(footerPath).text()
+    const afterOps = applyOpsToText(original, FOOTER_LOGO_OPS)
+    if (afterOps === original) return false // already cleaned — no-op
+
+    // JSX-element removal leaves the credit link's former indentation as a
+    // whitespace-only line; collapse it so the file stays `oxfmt`-clean.
+    const transformed = afterOps.replace(/\n[ \t]+\n/, '\n')
+
+    if (!dryRun) {
+      await Bun.write(footerPath, transformed)
+    }
+    return true
+  } catch (error) {
+    p.log.error(`Failed to remove branding from footer: ${error}`)
+    return false
+  }
+}
+
+/**
  * Remove Satūs-specific branding and assets (cross-platform)
  */
 const removeBrandingAssets = async (dryRun: boolean): Promise<boolean> => {
@@ -153,6 +202,10 @@ const removeBrandingAssets = async (dryRun: boolean): Promise<boolean> => {
     if (await removeFile(file, dryRun)) {
       removedCount++
     }
+  }
+
+  if (await removeFooterLogo(dryRun)) {
+    removedCount++
   }
 
   return removedCount > 0

--- a/lib/scripts/templates/inventory.ts
+++ b/lib/scripts/templates/inventory.ts
@@ -90,8 +90,6 @@ export function renderInventory({
     '- Could not scan effect components'
   )
 
-  // Pages section intentionally has no trailing blank line (matches the
-  // original generator, which ended the document on the last page entry).
   lines.push('## Pages')
   lines.push('')
   if (pages === null) {
@@ -101,6 +99,10 @@ export function renderInventory({
       lines.push(`- \`/${route}\``)
     }
   }
+  // Trailing blank line so the joined text ends in `\n`, matching
+  // deployment-checklist.ts's pattern — a document without one fails
+  // `oxfmt --check` (P-C2).
+  lines.push('')
 
   return lines.join('\n')
 }

--- a/lib/scripts/templates/templates.test.ts
+++ b/lib/scripts/templates/templates.test.ts
@@ -189,4 +189,18 @@ describe('renderInventory', () => {
     expect(output).toContain('- Could not scan effect components')
     expect(output).toContain('- Could not scan pages')
   })
+
+  it('ends with a trailing newline (P-C2 — required for oxfmt --check)', () => {
+    const output = renderInventory({
+      date: '2026-01-01',
+      integrations: [],
+      uiComponents: [],
+      layoutComponents: [],
+      effectComponents: [],
+      pages: ['about'],
+    })
+
+    expect(output.endsWith('\n')).toBe(true)
+    expect(output.endsWith('\n\n')).toBe(false)
+  })
 })


### PR DESCRIPTION
## What this does
Two process-audit Highs, both 100% reproducible: every \`bun run handoff\` deleted \`darkroom.svg\` while the footer still imported it (build broken with Module not found), and every generated INVENTORY.md lacked a trailing newline (check broken at the format gate).

Handoff now transforms the footer as part of branding removal — the whole Darkroom credit link goes, via the existing AST-transform engine, idempotently — and the inventory template ends with a newline like its checklist sibling. Findings P-C1 + P-C2.

## Test Plan
- [x] Real handoff run in a throwaway copy (harness-driven) → \`bun run build\` exit 0, oxfmt clean on INVENTORY.md and the transformed footer
- [x] Transform idempotence: re-applying is a byte-for-byte no-op
- [x] \`bun run check\` → 433 pass with the new template test