### PR TITLE
fix(scripts): make the setup:project strip's output actually build

### DIFF
--- a/lib/scripts/ast-operation-types.ts
+++ b/lib/scripts/ast-operation-types.ts
@@ -4,15 +4,109 @@
  * Contains only exported interface/type declarations — zero runtime code.
  */
 
+/**
+ * Shared by every op: a required-match contract (cross-model review
+ * finding). When `required` is true and the op matches nothing on the file
+ * it's applied to, the runner (`applyOpsToText` in `ast-transforms/index.ts`)
+ * throws instead of silently leaving the file unchanged — a source shape
+ * that drifted out from under a strip transform (a rename, a moved
+ * function, a restructured try/catch) would otherwise strip an import while
+ * leaving the code that used it, producing a tree that fails to build with
+ * no signal until `bun run build` — by which point `setup:project` has
+ * already self-pruned the machinery that could have caught it.
+ *
+ * Defaults to false/undefined: most ops are intentionally best-effort or
+ * idempotent by design (e.g. an additive op that's a legitimate no-op
+ * because the construct is already present, or a removal op reapplied to an
+ * already-lean file via `stripAbsentIntegrationWiring`) — `required` is only
+ * safe to set on ops whose single, deterministic application point is
+ * guaranteed to see pristine, never-before-touched source (see each op's
+ * `required: true` usage in `integration-bundles.ts` / `setup-project.ts`
+ * for the reasoning).
+ */
+export interface RequiredMatchOp {
+  /**
+   * When true, zero matches for this op on the file it's applied to is a
+   * hard failure, not a silent no-op.
+   */
+  required?: boolean
+}
+
 /** Remove a top-level import declaration by its module specifier. */
-export interface RemoveImportOp {
+export interface RemoveImportOp extends RequiredMatchOp {
   kind: 'removeImport'
   /** The module specifier string to match exactly, e.g. '@/webgl/components/canvas' */
   specifier: string
 }
 
+/**
+ * Remove a single named binding from an existing import declaration, keeping
+ * any other named/default/namespace bindings on that declaration intact.
+ * When the removed binding was the declaration's only binding, the whole
+ * declaration is removed (mirrors `removeImport`'s cleanup). No-op when the
+ * specifier or the named binding isn't found.
+ *
+ * Use this instead of `removeImport` when a declaration is shared by bindings
+ * owned by different integrations, e.g. `import { type NextRequest,
+ * NextResponse } from 'next/server'` where only `NextResponse` is
+ * sanity-owned and `NextRequest` must survive (it types the shared handler's
+ * parameter).
+ */
+export interface RemoveNamedImportOp extends RequiredMatchOp {
+  kind: 'removeNamedImport'
+  /** Module specifier of the import declaration to target, e.g. 'next/server' */
+  specifier: string
+  /** The named import to remove, e.g. 'NextResponse' */
+  name: string
+}
+
+/**
+ * Remove a `try { … } catch { … }` statement whose try-block source text
+ * contains `blockContains` (disambiguates multiple try statements in the same
+ * file). Matches at any scope depth; removes every occurrence, including its
+ * own leading comments. Pure deletion — no replacement — mirrors
+ * `removeIfStatement`.
+ */
+export interface RemoveTryStatementOp extends RequiredMatchOp {
+  kind: 'removeTryStatement'
+  /** Substring to match against the try block's own source text. */
+  blockContains: string
+}
+
+/**
+ * Remove a `'use cache'` directive that sits as the first statement of a
+ * named function's body. No-op when the function isn't found or its first
+ * statement isn't a `'use cache'` directive.
+ *
+ * Used to keep a `'use cache'` boundary from becoming a hard Next.js compile
+ * error once Cache Components is disabled (`cacheComponents: false` requires
+ * every `'use cache'` boundary in the app to be gone too) — see
+ * `setupCacheComponentsOptOut`.
+ */
+export interface RemoveUseCacheDirectiveOp extends RequiredMatchOp {
+  kind: 'removeUseCacheDirective'
+  /** Name of the function whose leading directive to remove, e.g. 'buildBody' */
+  functionName: string
+}
+
+/**
+ * Replace the entire body of a named function with `replacement` (source
+ * text including the surrounding braces, e.g. `{ return [] }`). Used to gut a
+ * function down to a lean stub when the codeTransform machinery can't express
+ * a targeted removal inside a complex body (mirrors `replaceJsDoc`'s
+ * whole-block-replacement approach, applied to a function body instead of a
+ * JSDoc comment).
+ */
+export interface ReplaceFunctionBodyOp extends RequiredMatchOp {
+  kind: 'replaceFunctionBody'
+  /** Name of the function whose body to replace, e.g. 'getCmsRoutes' */
+  functionName: string
+  /** Replacement body text, including braces, e.g. '{\n  return []\n}' */
+  replacement: string
+}
+
 /** Remove a `const NAME = …` variable statement by name (any scope depth). */
-export interface RemoveVariableStatementOp {
+export interface RemoveVariableStatementOp extends RequiredMatchOp {
   kind: 'removeVariableStatement'
   /** The variable name to remove, e.g. 'LazyWebGLCanvas' */
   name: string
@@ -23,7 +117,7 @@ export interface RemoveVariableStatementOp {
  * `useTheatre(sheet, 'fluid simulation', { … })` statement. Matches at any
  * scope depth; removes every occurrence in the file.
  */
-export interface RemoveCallStatementOp {
+export interface RemoveCallStatementOp extends RequiredMatchOp {
   kind: 'removeCallStatement'
   /** The called identifier, e.g. 'useTheatre' */
   callee: string
@@ -35,7 +129,7 @@ export interface RemoveCallStatementOp {
  * so the remaining `useContextBridge(TransformContext)` stops depending on the
  * stripped Theatre.js module. No-op when the argument is already absent.
  */
-export interface RemoveCallArgumentOp {
+export interface RemoveCallArgumentOp extends RequiredMatchOp {
   kind: 'removeCallArgument'
   /** The called identifier, e.g. 'useContextBridge' */
   callee: string
@@ -51,7 +145,7 @@ export interface RemoveCallArgumentOp {
  * - `unwrap` — when true, keep the element's children and remove only the
  *   opening / closing tags (e.g. strip <Canvas> but keep its content).
  */
-export interface RemoveJsxElementOp {
+export interface RemoveJsxElementOp extends RequiredMatchOp {
   kind: 'removeJsxElement'
   /** JSX tag name, e.g. 'LazyWebGLCanvas', 'Canvas', 'OrchestraToggle' */
   tagName: string
@@ -62,7 +156,7 @@ export interface RemoveJsxElementOp {
 }
 
 /** Remove a property (with its leading JSDoc) from a named interface. */
-export interface RemoveInterfacePropertyOp {
+export interface RemoveInterfacePropertyOp extends RequiredMatchOp {
   kind: 'removeInterfaceProperty'
   /** Interface name, e.g. 'WrapperProps' */
   interfaceName: string
@@ -77,7 +171,7 @@ export interface RemoveInterfacePropertyOp {
  * @example Remove `webgl` prop from every `<Wrapper webgl …>` usage:
  * `{ kind: 'removeJsxAttribute', tagName: 'Wrapper', attributeName: 'webgl' }`
  */
-export interface RemoveJsxAttributeOp {
+export interface RemoveJsxAttributeOp extends RequiredMatchOp {
   kind: 'removeJsxAttribute'
   /** Tag name of the element whose attribute to remove, e.g. 'Wrapper' */
   tagName: string
@@ -94,7 +188,7 @@ export interface RemoveJsxAttributeOp {
  * @example Remove `studio` from `const { stats, grid, studio } = useOrchestra()`
  * `{ kind: 'removeDestructuredBinding', variableName: 'studio', declarationPattern: 'useOrchestra' }`
  */
-export interface RemoveDestructuredBindingOp {
+export interface RemoveDestructuredBindingOp extends RequiredMatchOp {
   kind: 'removeDestructuredBinding'
   /** The binding name to remove, e.g. 'studio' */
   bindingName: string
@@ -107,7 +201,7 @@ export interface RemoveDestructuredBindingOp {
 }
 
 /** Remove a named parameter from a function's destructured props argument. */
-export interface RemoveFunctionParameterOp {
+export interface RemoveFunctionParameterOp extends RequiredMatchOp {
   kind: 'removeFunctionParameter'
   /** Exported function name, e.g. 'Wrapper' */
   functionName: string
@@ -120,7 +214,7 @@ export interface RemoveFunctionParameterOp {
  * Used when multiple partial-text edits to the JSDoc would be brittle; a full
  * replacement is simpler and guarantees the result is well-formed.
  */
-export interface ReplaceJsDocOp {
+export interface ReplaceJsDocOp extends RequiredMatchOp {
   kind: 'replaceJsDoc'
   /** Name of the function whose JSDoc to replace */
   functionName: string
@@ -143,7 +237,7 @@ export interface ReplaceJsDocOp {
  * @example Remove the Shopify webhook dispatch:
  * `{ kind: 'removeIfStatement', conditionContains: 'isShopifyWebhook' }`
  */
-export interface RemoveIfStatementOp {
+export interface RemoveIfStatementOp extends RequiredMatchOp {
   kind: 'removeIfStatement'
   /** Substring to match against the `if` statement's condition source text. */
   conditionContains: string
@@ -156,7 +250,7 @@ export interface RemoveIfStatementOp {
  * Matches an array element that is an object literal containing a property
  * whose name and string value both match the given `matchProperty`.
  */
-export interface RemoveArrayObjectElementOp {
+export interface RemoveArrayObjectElementOp extends RequiredMatchOp {
   kind: 'removeArrayObjectElement'
   /**
    * Dot-separated path from the variable declaration down to the array
@@ -173,7 +267,7 @@ export interface RemoveArrayObjectElementOp {
  * Remove a string-literal element from an array property nested inside a named
  * variable declaration.  Designed for `experimental.optimizePackageImports`.
  */
-export interface RemoveArrayStringElementOp {
+export interface RemoveArrayStringElementOp extends RequiredMatchOp {
   kind: 'removeArrayStringElement'
   /**
    * Dot-separated path from the variable declaration down to the array
@@ -208,7 +302,7 @@ export interface RemoveArrayStringElementOp {
  * already equals `valueText` — see `applySetObjectProperty`'s doc for the
  * exact conditions.
  */
-export interface SetObjectPropertyOp {
+export interface SetObjectPropertyOp extends RequiredMatchOp {
   kind: 'setObjectProperty'
   /** The variable name that holds the object, e.g. `'nextConfig'`. */
   variableName: string
@@ -236,7 +330,7 @@ export interface SetObjectPropertyOp {
  * Otherwise the declaration is inserted after the last existing import, e.g.
  * re-adding `import { Canvas } from '@/webgl/components/canvas'`.
  */
-export interface AddImportOp {
+export interface AddImportOp extends RequiredMatchOp {
   kind: 'addImport'
   /** Full import declaration text, e.g. `import { Canvas } from '@/webgl/components/canvas'` */
   text: string
@@ -249,7 +343,7 @@ export interface AddImportOp {
  *
  * No-op when an element with the same literal value already exists.
  */
-export interface AddArrayStringElementOp {
+export interface AddArrayStringElementOp extends RequiredMatchOp {
   kind: 'addArrayStringElement'
   /** The variable name that holds the object, e.g. `'nextConfig'`. */
   variableName: string
@@ -271,7 +365,7 @@ export interface AddArrayStringElementOp {
  * semantics as `removeArrayObjectElement`, including quoted-key
  * normalization).
  */
-export interface AddArrayObjectElementOp {
+export interface AddArrayObjectElementOp extends RequiredMatchOp {
   kind: 'addArrayObjectElement'
   /** The variable name that holds the object, e.g. `'nextConfig'`. */
   variableName: string
@@ -293,7 +387,7 @@ export interface AddArrayObjectElementOp {
  * No-op when a variable named `name` already exists anywhere in the file
  * (any scope depth, mirroring `removeVariableStatement`).
  */
-export interface AddVariableStatementOp {
+export interface AddVariableStatementOp extends RequiredMatchOp {
   kind: 'addVariableStatement'
   /** The declared variable name used for the idempotency check, e.g. 'LazyWebGLCanvas' */
   name: string
@@ -320,7 +414,7 @@ export interface AddVariableStatementOp {
  * `childTagName` already exists anywhere in the file — narrowed to elements
  * whose attribute matches when `childAttribute` is provided.
  */
-export interface AddJsxChildOp {
+export interface AddJsxChildOp extends RequiredMatchOp {
   kind: 'addJsxChild'
   /**
    * Tag name of the parent element to append into, e.g. 'Wrapper'.
@@ -339,8 +433,55 @@ export interface AddJsxChildOp {
   childAttribute?: { name: string; value: string }
 }
 
+/**
+ * Add a named binding to an existing destructured variable declaration.
+ * Inverse of `removeDestructuredBinding`.
+ *
+ * Targets `const { …, name, … } = expr` statements at any scope depth,
+ * narrowed by `initializerContains` (same matching semantics as
+ * `removeDestructuredBinding`). No-op when a binding with `bindingName`
+ * already exists on the matched pattern, or when no matching destructuring is
+ * found.
+ *
+ * @example Re-add `stats` to `const { grid, studio } = useOrchestra()`
+ * `{ kind: 'addDestructuredBinding', bindingName: 'stats', initializerContains: 'useOrchestra' }`
+ */
+export interface AddDestructuredBindingOp extends RequiredMatchOp {
+  kind: 'addDestructuredBinding'
+  /** The binding name to add, e.g. 'stats' */
+  bindingName: string
+  /**
+   * Substring of the initializer expression text used to find the target
+   * declaration (e.g. 'useOrchestra').
+   */
+  initializerContains: string
+}
+
+/**
+ * Insert a full statement into a named function's body. No-op when a
+ * statement containing `marker` already exists in the body (idempotency
+ * check, mirrors `addVariableStatement`'s name-based check).
+ *
+ * Positioning: when `afterContains` is given and a statement containing that
+ * substring exists, `text` is inserted immediately after it — a stable
+ * anchor independent of what other additive ops have already inserted.
+ * Otherwise `text` is appended as the body's last statement.
+ */
+export interface AddFunctionBodyStatementOp extends RequiredMatchOp {
+  kind: 'addFunctionBodyStatement'
+  /** Name of the function whose body to insert into, e.g. 'POST' */
+  functionName: string
+  /** Full statement text to insert. */
+  text: string
+  /** Substring used for the idempotency check against existing statements. */
+  marker: string
+  /** Optional anchor: insert immediately after the statement containing this substring. */
+  afterContains?: string
+}
+
 export type AstOperation =
   | RemoveImportOp
+  | RemoveNamedImportOp
   | RemoveVariableStatementOp
   | RemoveCallStatementOp
   | RemoveCallArgumentOp
@@ -351,6 +492,9 @@ export type AstOperation =
   | RemoveFunctionParameterOp
   | ReplaceJsDocOp
   | RemoveIfStatementOp
+  | RemoveTryStatementOp
+  | RemoveUseCacheDirectiveOp
+  | ReplaceFunctionBodyOp
   | RemoveArrayObjectElementOp
   | RemoveArrayStringElementOp
   | SetObjectPropertyOp
@@ -359,6 +503,8 @@ export type AstOperation =
   | AddArrayObjectElementOp
   | AddVariableStatementOp
   | AddJsxChildOp
+  | AddDestructuredBindingOp
+  | AddFunctionBodyStatementOp
 
 export interface CodeTransform {
   /** Path to the file to transform (relative to project root) */

--- a/lib/scripts/ast-transforms.ts
+++ b/lib/scripts/ast-transforms.ts
@@ -9,4 +9,8 @@
  *   ast-transforms/index.ts       — dispatch + disk API
  */
 
-export { applyCodeTransforms, applyOpsToText } from './ast-transforms/index'
+export {
+  applyCodeTransforms,
+  applyOpsToText,
+  RequiredOpMatchError,
+} from './ast-transforms/index'

--- a/lib/scripts/ast-transforms/add-ops.ts
+++ b/lib/scripts/ast-transforms/add-ops.ts
@@ -17,6 +17,8 @@ import {
 import type {
   AddArrayObjectElementOp,
   AddArrayStringElementOp,
+  AddDestructuredBindingOp,
+  AddFunctionBodyStatementOp,
   AddImportOp,
   AddJsxChildOp,
   AddVariableStatementOp,
@@ -191,6 +193,90 @@ export function applyAddVariableStatement(
       sf.addStatements(op.text)
     } else {
       sf.insertStatements(insertIndexAfterImports(sf), op.text)
+    }
+    return undefined // proceed with sf.getFullText()
+  })
+}
+
+/**
+ * Add a named binding to an existing destructured variable declaration.
+ * Inverse of `removeDestructuredBinding`. No-op when the binding already
+ * exists, or when no destructuring matches `initializerContains`.
+ */
+export function applyAddDestructuredBinding(
+  project: Project,
+  sourceText: string,
+  op: AddDestructuredBindingOp
+): string {
+  return withSourceFile(project, sourceText, (sf) => {
+    for (const stmt of sf.getDescendantsOfKind(SyntaxKind.VariableStatement)) {
+      for (const decl of stmt.getDeclarations()) {
+        const nameNode = decl.getNameNode()
+        if (nameNode.getKind() !== SyntaxKind.ObjectBindingPattern) continue
+
+        const pattern = nameNode.asKindOrThrow(SyntaxKind.ObjectBindingPattern)
+        const initText = decl.getInitializer()?.getText() ?? ''
+        if (!initText.includes(op.initializerContains)) continue
+
+        const elements = pattern.getElements()
+        if (elements.some((el) => el.getName() === op.bindingName)) {
+          return sourceText // already present — idempotent no-op
+        }
+
+        const names = [...elements.map((el) => el.getText()), op.bindingName]
+        pattern.replaceWithText(`{ ${names.join(', ')} }`)
+        return undefined // proceed with sf.getFullText()
+      }
+    }
+    return sourceText // no matching destructuring found
+  })
+}
+
+/**
+ * Insert `text` into a named function's body. No-op when a statement
+ * containing `marker` already exists. When `afterContains` matches an
+ * existing statement, `text` is inserted right after it; otherwise `text` is
+ * appended as the last statement.
+ */
+export function applyAddFunctionBodyStatement(
+  project: Project,
+  sourceText: string,
+  op: AddFunctionBodyStatementOp
+): string {
+  return withSourceFile(project, sourceText, (sf) => {
+    const fn = sf.getFunction(op.functionName)
+    if (!fn) return sourceText
+
+    const body = fn.getBody()
+    if (!body || body.getKind() !== SyntaxKind.Block) return sourceText
+    const block = body.asKindOrThrow(SyntaxKind.Block)
+
+    const statements = block.getStatements()
+    const exists = statements.some((s) => s.getText().includes(op.marker))
+    if (exists) return sourceText
+
+    // Raw text insertion (rather than `block.insertStatements(index, …)`)
+    // deliberately: ts-morph's numeric-index insertion mis-positions by one
+    // when a leading comment precedes the block's first statement (the index
+    // returned by `getStatements()` and the index `insertStatements` expects
+    // stop agreeing once trivia is involved).
+    const anchor = op.afterContains
+      ? statements.find((s) => s.getText().includes(op.afterContains as string))
+      : undefined
+
+    if (anchor) {
+      sf.insertText(anchor.getEnd(), `\n${op.text}`)
+      return undefined // proceed with sf.getFullText()
+    }
+
+    const last = statements[statements.length - 1]
+    if (last) {
+      sf.insertText(last.getEnd(), `\n${op.text}`)
+    } else {
+      const openBrace = block.getFirstChildByKindOrThrow(
+        SyntaxKind.OpenBraceToken
+      )
+      sf.insertText(openBrace.getEnd(), `\n${op.text}`)
     }
     return undefined // proceed with sf.getFullText()
   })

--- a/lib/scripts/ast-transforms/index.ts
+++ b/lib/scripts/ast-transforms/index.ts
@@ -15,6 +15,8 @@ import { resolvePath } from '../utils'
 import {
   applyAddArrayObjectElement,
   applyAddArrayStringElement,
+  applyAddDestructuredBinding,
+  applyAddFunctionBodyStatement,
   applyAddImport,
   applyAddJsxChild,
   applyAddVariableStatement,
@@ -31,10 +33,86 @@ import {
   applyRemoveInterfaceProperty,
   applyRemoveJsxAttribute,
   applyRemoveJsxElement,
+  applyRemoveNamedImport,
+  applyRemoveTryStatement,
+  applyRemoveUseCacheDirective,
   applyRemoveVariableStatement,
+  applyReplaceFunctionBody,
   applyReplaceJsDoc,
 } from './remove-ops'
 import { applySetObjectProperty } from './set-ops'
+
+// ---------------------------------------------------------------------------
+// Required-match contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown by `applyOpsToText` when a `required: true` op matches nothing —
+ * see `RequiredMatchOp`'s docstring in `ast-operation-types.ts` for the full
+ * rationale. Distinguished from a regular op-application error so
+ * `applyCodeTransforms` can re-throw it (hard-fail the whole run) instead of
+ * collecting it into `TransformFailure[]` like every other error.
+ */
+export class RequiredOpMatchError extends Error {
+  override readonly name = 'RequiredOpMatchError'
+}
+
+/** One-line, human-readable description of an op, for RequiredOpMatchError's message. */
+function describeOp(op: AstOperation): string {
+  switch (op.kind) {
+    case 'removeImport':
+      return `removeImport '${op.specifier}'`
+    case 'removeNamedImport':
+      return `removeNamedImport '${op.name}' from '${op.specifier}'`
+    case 'removeVariableStatement':
+      return `removeVariableStatement '${op.name}'`
+    case 'removeCallStatement':
+      return `removeCallStatement '${op.callee}'`
+    case 'removeCallArgument':
+      return `removeCallArgument '${op.argument}' from '${op.callee}'`
+    case 'removeJsxElement':
+      return `removeJsxElement '${op.tagName}'${op.attribute ? ` [${op.attribute.name}="${op.attribute.value}"]` : ''}`
+    case 'removeJsxAttribute':
+      return `removeJsxAttribute '${op.attributeName}' on '${op.tagName}'`
+    case 'removeDestructuredBinding':
+      return `removeDestructuredBinding '${op.bindingName}'`
+    case 'removeInterfaceProperty':
+      return `removeInterfaceProperty '${op.propertyName}' on '${op.interfaceName}'`
+    case 'removeFunctionParameter':
+      return `removeFunctionParameter '${op.parameterName}' on '${op.functionName}'`
+    case 'replaceJsDoc':
+      return `replaceJsDoc on '${op.functionName}'`
+    case 'removeIfStatement':
+      return `removeIfStatement '${op.conditionContains}'`
+    case 'removeTryStatement':
+      return `removeTryStatement '${op.blockContains}'`
+    case 'removeUseCacheDirective':
+      return `removeUseCacheDirective on '${op.functionName}'`
+    case 'replaceFunctionBody':
+      return `replaceFunctionBody on '${op.functionName}'`
+    case 'removeArrayObjectElement':
+      return `removeArrayObjectElement '${op.matchProperty.name}=${op.matchProperty.value}' from '${op.variableName}.${op.propertyPath}'`
+    case 'removeArrayStringElement':
+      return `removeArrayStringElement '${op.value}' from '${op.variableName}.${op.propertyPath}'`
+    case 'setObjectProperty':
+      return `setObjectProperty '${op.variableName}.${op.propertyPath}'`
+    case 'addImport':
+      return `addImport '${op.text}'`
+    case 'addArrayStringElement':
+      return `addArrayStringElement '${op.value}' to '${op.variableName}.${op.propertyPath}'`
+    case 'addArrayObjectElement':
+      return `addArrayObjectElement '${op.matchProperty.name}=${op.matchProperty.value}' to '${op.variableName}.${op.propertyPath}'`
+    case 'addVariableStatement':
+      return `addVariableStatement '${op.name}'`
+    case 'addJsxChild':
+      return `addJsxChild '${op.childTagName}' into '${op.parentTagName}'`
+    case 'addDestructuredBinding':
+      return `addDestructuredBinding '${op.bindingName}'`
+    case 'addFunctionBodyStatement':
+      return `addFunctionBodyStatement '${op.marker}' in '${op.functionName}'`
+    // Exhaustiveness — TypeScript ensures all union members are handled above.
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Per-file transform runner
@@ -49,6 +127,11 @@ import { applySetObjectProperty } from './set-ops'
  * any op kind — enabling the JSX handlers without affecting non-JSX ops.
  * Each handler creates and removes its own source file, so no AST state leaks
  * between sequential ops.
+ *
+ * Required-match contract: an op with `required: true` that leaves `text`
+ * byte-for-byte unchanged (no match found) throws `RequiredOpMatchError`
+ * instead of silently continuing — see `RequiredMatchOp`'s docstring in
+ * `ast-operation-types.ts`.
  */
 export function applyOpsToText(
   sourceText: string,
@@ -67,9 +150,13 @@ export function applyOpsToText(
   let text = sourceText
 
   for (const op of ops) {
+    const before = text
     switch (op.kind) {
       case 'removeImport':
         text = applyRemoveImport(project, text, op)
+        break
+      case 'removeNamedImport':
+        text = applyRemoveNamedImport(project, text, op)
         break
       case 'removeVariableStatement':
         text = applyRemoveVariableStatement(project, text, op)
@@ -101,6 +188,15 @@ export function applyOpsToText(
       case 'removeIfStatement':
         text = applyRemoveIfStatement(project, text, op)
         break
+      case 'removeTryStatement':
+        text = applyRemoveTryStatement(project, text, op)
+        break
+      case 'removeUseCacheDirective':
+        text = applyRemoveUseCacheDirective(project, text, op)
+        break
+      case 'replaceFunctionBody':
+        text = applyReplaceFunctionBody(project, text, op)
+        break
       case 'removeArrayObjectElement':
         text = applyRemoveArrayObjectElement(project, text, op)
         break
@@ -125,7 +221,19 @@ export function applyOpsToText(
       case 'addJsxChild':
         text = applyAddJsxChild(project, text, op)
         break
+      case 'addDestructuredBinding':
+        text = applyAddDestructuredBinding(project, text, op)
+        break
+      case 'addFunctionBodyStatement':
+        text = applyAddFunctionBodyStatement(project, text, op)
+        break
       // Exhaustiveness — TypeScript ensures all union members are handled above.
+    }
+
+    if (op.required && text === before) {
+      throw new RequiredOpMatchError(
+        `Required op matched nothing (source shape may have drifted): ${describeOp(op)}`
+      )
     }
   }
 
@@ -152,6 +260,16 @@ export interface TransformFailure {
  * reporting every failure at once). Failures are collected and returned
  * instead of only logged, so callers can fail loudly — and non-zero — once
  * the batch is done, rather than exiting 0 on a silently-incomplete run.
+ *
+ * Exception: a `RequiredOpMatchError` (a `required: true` op that matched
+ * nothing) is deliberately NOT collected into `failures` — it's re-thrown
+ * immediately, aborting this whole batch. Regular per-file failures are
+ * recoverable (the other files still get their intended changes; the run
+ * finishes and reports non-zero); a required-match miss means the source
+ * shape has drifted from what a strip transform expects, which risks
+ * leaving a broken tree (an import removed, the code that used it still
+ * there) — that must stop the run before `setup()` reaches self-prune, not
+ * just get reported alongside everything else at the end.
  */
 export async function applyCodeTransforms(
   transforms: CodeTransform[],
@@ -177,6 +295,9 @@ export async function applyCodeTransforms(
         totalChanges++
       }
     } catch (error) {
+      if (error instanceof RequiredOpMatchError) {
+        throw new RequiredOpMatchError(`${transform.file}: ${error.message}`)
+      }
       failures.push({
         file: transform.file,
         error: error instanceof Error ? error.message : String(error),

--- a/lib/scripts/ast-transforms/remove-ops.ts
+++ b/lib/scripts/ast-transforms/remove-ops.ts
@@ -21,7 +21,11 @@ import type {
   RemoveInterfacePropertyOp,
   RemoveJsxAttributeOp,
   RemoveJsxElementOp,
+  RemoveNamedImportOp,
+  RemoveTryStatementOp,
+  RemoveUseCacheDirectiveOp,
   RemoveVariableStatementOp,
+  ReplaceFunctionBodyOp,
   ReplaceJsDocOp,
 } from '../ast-operation-types'
 import {
@@ -44,6 +48,39 @@ export function applyRemoveImport(
         break
       }
     }
+  })
+}
+
+/**
+ * Remove a single named binding from an import declaration, keeping other
+ * bindings on the same declaration. Removes the whole declaration when the
+ * removed binding was its only one (no default/namespace import left either).
+ */
+export function applyRemoveNamedImport(
+  project: Project,
+  sourceText: string,
+  op: RemoveNamedImportOp
+): string {
+  return withSourceFile(project, sourceText, (sf) => {
+    const decl = sf
+      .getImportDeclarations()
+      .find((d) => d.getModuleSpecifierValue() === op.specifier)
+    if (!decl) return sourceText
+
+    const named = decl.getNamedImports().find((n) => n.getName() === op.name)
+    if (!named) return sourceText
+
+    named.remove()
+
+    if (
+      decl.getNamedImports().length === 0 &&
+      !decl.getDefaultImport() &&
+      !decl.getNamespaceImport()
+    ) {
+      decl.remove()
+    }
+
+    return undefined // proceed with sf.getFullText()
   })
 }
 
@@ -116,6 +153,84 @@ export function applyRemoveIfStatement(
 
       sf.removeText(stmt.getFullStart(), stmt.getEnd())
     }
+  })
+}
+
+/**
+ * Remove a `try { … } catch { … }` statement whose try-block text contains
+ * `blockContains`. Pure deletion (no replacement) — mirrors
+ * `applyRemoveIfStatement`.
+ */
+export function applyRemoveTryStatement(
+  project: Project,
+  sourceText: string,
+  op: RemoveTryStatementOp
+): string {
+  return withSourceFile(project, sourceText, (sf) => {
+    while (true) {
+      const stmt = sf
+        .getDescendantsOfKind(SyntaxKind.TryStatement)
+        .find((s) => s.getTryBlock().getText().includes(op.blockContains))
+      if (!stmt) break
+
+      sf.removeText(stmt.getFullStart(), stmt.getEnd())
+    }
+  })
+}
+
+/**
+ * Remove a `'use cache'` directive sitting as the first statement of a named
+ * function's body. No-op when the function isn't found, or its first
+ * statement isn't a `'use cache'` string-literal expression statement.
+ */
+export function applyRemoveUseCacheDirective(
+  project: Project,
+  sourceText: string,
+  op: RemoveUseCacheDirectiveOp
+): string {
+  return withSourceFile(project, sourceText, (sf) => {
+    const fn = sf.getFunction(op.functionName)
+    if (!fn) return sourceText
+
+    const body = fn.getBody()
+    if (!body || body.getKind() !== SyntaxKind.Block) return sourceText
+    const block = body.asKindOrThrow(SyntaxKind.Block)
+
+    const first = block.getStatements()[0]
+    if (!first) return sourceText
+
+    const expr = first.asKind(SyntaxKind.ExpressionStatement)?.getExpression()
+    if (!expr || expr.getKind() !== SyntaxKind.StringLiteral) return sourceText
+    if (
+      expr.asKindOrThrow(SyntaxKind.StringLiteral).getLiteralValue() !==
+      'use cache'
+    ) {
+      return sourceText
+    }
+
+    sf.removeText(first.getFullStart(), first.getEnd())
+    return undefined // proceed with sf.getFullText()
+  })
+}
+
+/**
+ * Replace a named function's entire body with `replacement` (source text
+ * including the surrounding braces). No-op when the function isn't found.
+ */
+export function applyReplaceFunctionBody(
+  project: Project,
+  sourceText: string,
+  op: ReplaceFunctionBodyOp
+): string {
+  return withSourceFile(project, sourceText, (sf) => {
+    const fn = sf.getFunction(op.functionName)
+    if (!fn) return sourceText
+
+    const body = fn.getBody()
+    if (!body) return sourceText
+
+    body.replaceWithText(op.replacement)
+    return undefined // proceed with sf.getFullText()
   })
 }
 

--- a/lib/scripts/bundle-installer.ts
+++ b/lib/scripts/bundle-installer.ts
@@ -348,6 +348,16 @@ export const installBundle = async (
  * on disk, apply its subtractive `codeTransforms`. These ops are no-ops on
  * files already in the lean state, so calling this after an install is safe.
  *
+ * Downgrades every op's `required` flag to false before applying (regardless
+ * of how the bundle definition set it): by the time this runs, `setupLean`'s
+ * union pass has already applied every bundle's codeTransforms — including
+ * these — to the project's original files exactly once, which is where a
+ * required-match violation (drifted source) is caught. This is a genuinely
+ * separate, later pass over whatever's on disk NOW for a bundle that isn't
+ * kept; finding nothing left to strip here is the expected, idempotent
+ * outcome, not a sign of drift — enforcing `required` a second time here
+ * would false-positive on every preset that doesn't keep every integration.
+ *
  * @param installedOrAdded - Set (or array) of integration ids that are being
  *   added / were already added in this run and should NOT be stripped.
  * @param dryRun - When true, count changes but do not write files.
@@ -371,5 +381,10 @@ export const stripAbsentIntegrationWiring = async (
   }
 
   if (stripTransforms.length === 0) return { changes: 0, failures: [] }
-  return applyCodeTransforms(stripTransforms, dryRun)
+
+  const nonRequiredTransforms = stripTransforms.map((transform) => ({
+    ...transform,
+    ops: transform.ops.map((op) => ({ ...op, required: false })),
+  }))
+  return applyCodeTransforms(nonRequiredTransforms, dryRun)
 }

--- a/lib/scripts/integration-bundles.ts
+++ b/lib/scripts/integration-bundles.ts
@@ -18,6 +18,8 @@ import type { CodeTransform } from './ast-operation-types'
 export type {
   AddArrayObjectElementOp,
   AddArrayStringElementOp,
+  AddDestructuredBindingOp,
+  AddFunctionBodyStatementOp,
   AddImportOp,
   AddJsxChildOp,
   AddVariableStatementOp,
@@ -34,8 +36,13 @@ export type {
   RemoveInterfacePropertyOp,
   RemoveJsxAttributeOp,
   RemoveJsxElementOp,
+  RemoveNamedImportOp,
+  RemoveTryStatementOp,
+  RemoveUseCacheDirectiveOp,
   RemoveVariableStatementOp,
+  ReplaceFunctionBodyOp,
   ReplaceJsDocOp,
+  RequiredMatchOp,
 } from './ast-operation-types'
 
 export interface BarrelExport {
@@ -191,11 +198,108 @@ export const INTEGRATION_BUNDLES = defineBundles({
           },
         ],
       },
+      // lib/seo/routes.ts is a SHARED SEO surface (feeds app/sitemap.ts and
+      // app/llms.txt/route.ts) that stays present in every preset, but its
+      // getCmsRoutes() implementation is entirely Sanity-specific. Strip it
+      // to a lean stub that always returns [] — callers already degrade
+      // gracefully to STATIC_ROUTES / an empty Content section (P-B7: a
+      // no-sanity strip left this file's `next-sanity`/sanity imports
+      // unstripped, breaking the build once sanity's own deps were removed).
+      {
+        file: 'lib/seo/routes.ts',
+        // Every op here is `required: true`: this file is single-owner
+        // (only sanity touches it) and this array runs exactly once against
+        // pristine source per setup() run, so a zero-match here can only
+        // mean the source shape drifted (e.g. getCmsRoutes renamed) — never
+        // a legitimate idempotent re-application. See RequiredMatchOp's
+        // docstring in ast-operation-types.ts.
+        ops: [
+          {
+            kind: 'removeImport',
+            specifier: '@/integrations/registry',
+            required: true,
+          },
+          {
+            kind: 'removeImport',
+            specifier: '@/integrations/sanity/live',
+            required: true,
+          },
+          {
+            kind: 'removeImport',
+            specifier: '@/integrations/sanity/utils/link',
+            required: true,
+          },
+          { kind: 'removeImport', specifier: 'next-sanity', required: true },
+          { kind: 'removeImport', specifier: 'zod', required: true },
+          {
+            kind: 'removeVariableStatement',
+            name: 'routableDocumentSchema',
+            required: true,
+          },
+          {
+            kind: 'removeVariableStatement',
+            name: 'routableContentQuery',
+            required: true,
+          },
+          {
+            kind: 'removeVariableStatement',
+            name: 'staticPaths',
+            required: true,
+          },
+          {
+            kind: 'replaceFunctionBody',
+            functionName: 'getCmsRoutes',
+            replacement: '{\n  return []\n}',
+            required: true,
+          },
+        ],
+      },
+      // app/api/revalidate/route.ts is a SHARED webhook endpoint — Shopify
+      // owns its own guard/dispatch (see the shopify bundle's codeTransforms
+      // on this same file); everything else in the handler (the
+      // next-sanity/webhook parseBody call, NextResponse.json success path,
+      // revalidateTag calls) is Sanity's own logic and must be stripped when
+      // Sanity isn't kept, or `next-sanity` being removed from package.json
+      // breaks the build (P-B7).
+      {
+        file: 'app/api/revalidate/route.ts',
+        // required: true on all four — this is sanity's half of a two-owner
+        // file, applied exactly once per run against the pristine file by
+        // setupLean's union pass. stripAbsentIntegrationWiring (which CAN
+        // legitimately reapply this same array a second time, against an
+        // already-lean file, when sanity is absent but shopify is kept)
+        // downgrades `required` to false before calling applyCodeTransforms
+        // — see its docstring in bundle-installer.ts.
+        ops: [
+          {
+            kind: 'removeImport',
+            specifier: 'next-sanity/webhook',
+            required: true,
+          },
+          { kind: 'removeImport', specifier: 'next/cache', required: true },
+          {
+            kind: 'removeNamedImport',
+            specifier: 'next/server',
+            name: 'NextResponse',
+            required: true,
+          },
+          {
+            kind: 'removeTryStatement',
+            blockContains: 'SANITY_REVALIDATE_SECRET',
+            required: true,
+          },
+        ],
+      },
     ],
     // app/(site)/layout.tsx has complex Sanity wiring (SanityLive, VisualEditing,
     // isConfigured call) that cannot be re-injected statement-by-statement
     // safely.  Restore wholesale from the payload on `satus add sanity`.
-    overwriteFiles: ['app/(site)/layout.tsx'],
+    // lib/seo/routes.ts's only owner is Sanity (no other bundle touches it),
+    // so a wholesale restore on `satus add sanity` is safe — unlike
+    // app/api/revalidate/route.ts below, which Shopify also owns and must be
+    // restored surgically via addTransforms instead (overwriteFiles would
+    // reintroduce Shopify's wiring even when Shopify isn't kept).
+    overwriteFiles: ['app/(site)/layout.tsx', 'lib/seo/routes.ts'],
     addTransforms: [
       {
         file: 'next.config.ts',
@@ -235,6 +339,71 @@ export const INTEGRATION_BUNDLES = defineBundles({
           },
         ],
       },
+      // app/api/revalidate/route.ts is shared with Shopify (see that
+      // bundle's addTransforms on the same file) — restored surgically here
+      // rather than via overwriteFiles so keeping Sanity without Shopify
+      // never reintroduces Shopify's guard/dispatch import.
+      {
+        file: 'app/api/revalidate/route.ts',
+        ops: [
+          {
+            kind: 'addImport',
+            text: "import { parseBody } from 'next-sanity/webhook'",
+          },
+          {
+            kind: 'addImport',
+            text: "import { revalidateTag } from 'next/cache'",
+          },
+          {
+            kind: 'addImport',
+            text: "import { NextResponse } from 'next/server'",
+          },
+          {
+            kind: 'addFunctionBodyStatement',
+            functionName: 'POST',
+            marker: 'SANITY_REVALIDATE_SECRET',
+            text: `  try {
+    const secret = process.env.SANITY_REVALIDATE_SECRET
+    if (!secret) {
+      return new Response('Webhook secret not configured', { status: 503 })
+    }
+
+    const { body, isValidSignature } = await parseBody<{
+      _type: string
+      slug?: { current: string }
+    }>(request, secret)
+
+    if (!isValidSignature) {
+      return new Response('Invalid signature', { status: 401 })
+    }
+
+    if (!body?._type) {
+      return new Response('Bad Request', { status: 400 })
+    }
+
+    revalidateTag(body._type, {})
+
+    if (body.slug?.current) {
+      revalidateTag(\`\${body._type}:\${body.slug.current}\`, {})
+    }
+
+    return NextResponse.json({
+      status: 200,
+      revalidated: true,
+      now: Date.now(),
+    })
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      console.warn('Revalidation client error: invalid JSON body', error)
+      return new Response('Invalid JSON body', { status: 400 })
+    }
+
+    console.error('Revalidation error:', error)
+    return new Response('Internal Server Error', { status: 500 })
+  }`,
+          },
+        ],
+      },
     ],
   },
 
@@ -266,11 +435,10 @@ export const INTEGRATION_BUNDLES = defineBundles({
           },
         ],
       },
-      // app/api/revalidate/route.ts is a SHARED core route (not deleted by any
-      // bundle's `folders`/`files` — Sanity's revalidation logic in the same
-      // file has no bundle ownership either). Only Shopify currently wires
-      // anything into it, so stripping Shopify must remove exactly its own
-      // import + guard dispatch and nothing else.
+      // app/api/revalidate/route.ts is a SHARED core route — Sanity also owns
+      // part of it (its own codeTransforms entry on this file, above).
+      // Stripping Shopify must remove exactly its own import + guard dispatch
+      // and nothing else.
       {
         file: 'app/api/revalidate/route.ts',
         ops: [
@@ -292,15 +460,6 @@ export const INTEGRATION_BUNDLES = defineBundles({
         ],
       },
     ],
-    // The Shopify webhook dispatch (import + guard variable + if-statement)
-    // lives inside the exported `POST` function body, not at the top level —
-    // none of the existing additive ops can re-insert a statement mid-function,
-    // so the file is restored wholesale on `satus add shopify`, guarded by the
-    // lean-state comparison documented on `overwriteFiles`. Safe because no
-    // other bundle currently owns any part of this file (see codeTransforms
-    // comment above) — the "expected lean" check only ever compares against
-    // Shopify's own removal ops.
-    overwriteFiles: ['app/api/revalidate/route.ts'],
     addTransforms: [
       {
         file: 'next.config.ts',
@@ -312,6 +471,32 @@ export const INTEGRATION_BUNDLES = defineBundles({
             propertyPath: 'images.remotePatterns',
             objectText: "{ protocol: 'https', hostname: 'cdn.shopify.com' }",
             matchProperty: { name: 'hostname', value: 'cdn.shopify.com' },
+          },
+        ],
+      },
+      // app/api/revalidate/route.ts is shared with Sanity (see that bundle's
+      // addTransforms on the same file). Insert right after the rate-limit
+      // early-return so the guard runs before Sanity's webhook handling
+      // regardless of which bundle's addTransforms runs first.
+      {
+        file: 'app/api/revalidate/route.ts',
+        ops: [
+          {
+            kind: 'addImport',
+            text: "import { revalidate as shopifyRevalidate } from '@/integrations/shopify/revalidate'",
+          },
+          {
+            kind: 'addFunctionBodyStatement',
+            functionName: 'POST',
+            marker: 'isShopifyWebhook',
+            afterContains: 'Too many requests',
+            text: `  const isShopifyWebhook =
+    request.headers.has('x-shopify-topic') ||
+    request.nextUrl.searchParams.has('secret')
+
+  if (isShopifyWebhook) {
+    return shopifyRevalidate(request)
+  }`,
           },
         ],
       },
@@ -363,7 +548,13 @@ export const INTEGRATION_BUNDLES = defineBundles({
       'tunnel-rat',
     ],
     devDependencies: ['@types/three'],
-    folders: ['lib/webgl'],
+    // lib/dev/stats renders a WebGL frame-time/GPU meter via `stats-gl`, a
+    // package that isn't a direct project dependency — it's only present in
+    // node_modules as a transitive dependency of `@react-three/drei` above.
+    // Stripping webgl removes that package too, so lib/dev/stats must live
+    // and die with the bundle (P-B7: it was orphaned, breaking any no-webgl
+    // build on module-not-found).
+    folders: ['lib/webgl', 'lib/dev/stats'],
     files: ['lib/hooks/use-device-detection.ts'],
     envVars: [],
     barrelExports: [
@@ -408,10 +599,45 @@ export const INTEGRATION_BUNDLES = defineBundles({
         file: 'lib/dev/cmdo.tsx',
         ops: [
           // Remove only the webgl OrchestraToggle (disambiguate by id attr)
+          // — pre-existing op, left unmarked (see RequiredMatchOp's
+          // docstring: legacy ops keep their existing no-op-on-miss semantics).
           {
             kind: 'removeJsxElement',
             tagName: 'OrchestraToggle',
             attribute: { name: 'id', value: 'webgl' },
+          },
+          // The stats-gl overlay needs a WebGL canvas — remove its toggle too.
+          // required: true — this array runs once against pristine source
+          // per setup() run (stripAbsentIntegrationWiring's later reapplication
+          // downgrades `required`, see its docstring in bundle-installer.ts).
+          {
+            kind: 'removeJsxElement',
+            tagName: 'OrchestraToggle',
+            attribute: { name: 'id', value: 'stats' },
+            required: true,
+          },
+        ],
+      },
+      {
+        file: 'lib/dev/index.tsx',
+        // Every op here is new (P-B7, the stats-gl orphan fix) and
+        // `required: true` for the same reason as lib/seo/routes.ts above.
+        ops: [
+          // Remove `const Stats = dynamic(…)` (imports the webgl-only stats-gl overlay)
+          {
+            kind: 'removeVariableStatement',
+            name: 'Stats',
+            required: true,
+          },
+          // Remove `{stats && <Stats />}` JSX expression
+          { kind: 'removeJsxElement', tagName: 'Stats', required: true },
+          // Remove `stats` from `const { stats, grid, … } = useOrchestra()`
+          // (unused after the JSX element above is gone — TS6133)
+          {
+            kind: 'removeDestructuredBinding',
+            bindingName: 'stats',
+            initializerContains: 'useOrchestra',
+            required: true,
           },
         ],
       },
@@ -560,6 +786,42 @@ export const INTEGRATION_BUNDLES = defineBundles({
               '<OrchestraToggle id="webgl" defaultValue={true}>🧊</OrchestraToggle>',
             childTagName: 'OrchestraToggle',
             childAttribute: { name: 'id', value: 'webgl' },
+          },
+          // Re-add the stats OrchestraToggle next to the other toggles
+          {
+            kind: 'addJsxChild',
+            parentTagName: 'div',
+            childText: '<OrchestraToggle id="stats">📈</OrchestraToggle>',
+            childTagName: 'OrchestraToggle',
+            childAttribute: { name: 'id', value: 'stats' },
+          },
+        ],
+      },
+      {
+        file: 'lib/dev/index.tsx',
+        ops: [
+          // Ensure the dynamic() helper import is present
+          { kind: 'addImport', text: "import dynamic from 'next/dynamic'" },
+          // Re-add `stats` to `const { grid, … } = useOrchestra()`
+          {
+            kind: 'addDestructuredBinding',
+            bindingName: 'stats',
+            initializerContains: 'useOrchestra',
+          },
+          // Re-add `const Stats = dynamic(…)`
+          {
+            kind: 'addVariableStatement',
+            name: 'Stats',
+            text: `const Stats = dynamic(() => import('./stats').then(({ Stats }) => Stats), {
+  ssr: false,
+})`,
+          },
+          // Re-add `{stats && <Stats />}` inside the OrchestraTools fragment
+          {
+            kind: 'addJsxChild',
+            parentTagName: 'Fragment',
+            childText: '{stats && <Stats />}',
+            childTagName: 'Stats',
           },
         ],
       },

--- a/lib/scripts/setup-project.test.ts
+++ b/lib/scripts/setup-project.test.ts
@@ -11,8 +11,11 @@
  */
 
 import { beforeAll, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
 
-import { applyOpsToText } from './ast-transforms'
+import { applyOpsToText, RequiredOpMatchError } from './ast-transforms'
 import {
   getIntegrationEntries,
   getIntegrationNames,
@@ -31,7 +34,7 @@ import {
   shouldDisableCacheComponents,
   shouldSkipConfirm,
 } from './setup-project'
-import { getFlagValue } from './utils'
+import { getFlagValue, pathExists, projectRoot } from './utils'
 
 // ---------------------------------------------------------------------------
 // Source file fixtures — loaded once, never written to disk
@@ -97,6 +100,7 @@ describe('Integration Bundle Configuration', () => {
           // Every op must have a known kind
           expect([
             'removeImport',
+            'removeNamedImport',
             'removeVariableStatement',
             'removeCallStatement',
             'removeCallArgument',
@@ -105,6 +109,8 @@ describe('Integration Bundle Configuration', () => {
             'removeFunctionParameter',
             'replaceJsDoc',
             'removeIfStatement',
+            'removeTryStatement',
+            'replaceFunctionBody',
             'removeArrayObjectElement',
             'removeArrayStringElement',
             'removeJsxAttribute',
@@ -147,6 +153,14 @@ describe('Integration Bundle Configuration', () => {
             expect(op.attributeName).toBeTruthy()
           } else if (op.kind === 'removeDestructuredBinding') {
             expect(op.bindingName).toBeTruthy()
+          } else if (op.kind === 'removeNamedImport') {
+            expect(op.specifier).toBeTruthy()
+            expect(op.name).toBeTruthy()
+          } else if (op.kind === 'removeTryStatement') {
+            expect(op.blockContains).toBeTruthy()
+          } else if (op.kind === 'replaceFunctionBody') {
+            expect(op.functionName).toBeTruthy()
+            expect(op.replacement).toBeTruthy()
           }
         }
       }
@@ -162,6 +176,8 @@ describe('Integration Bundle Configuration', () => {
       'addArrayObjectElement',
       'addVariableStatement',
       'addJsxChild',
+      'addDestructuredBinding',
+      'addFunctionBodyStatement',
     ]
 
     for (const [_name, bundle] of getIntegrationEntries()) {
@@ -192,6 +208,13 @@ describe('Integration Bundle Configuration', () => {
             expect(op.parentTagName).toBeTruthy()
             expect(op.childText).toBeTruthy()
             expect(op.childTagName).toBeTruthy()
+          } else if (op.kind === 'addDestructuredBinding') {
+            expect(op.bindingName).toBeTruthy()
+            expect(op.initializerContains).toBeTruthy()
+          } else if (op.kind === 'addFunctionBodyStatement') {
+            expect(op.functionName).toBeTruthy()
+            expect(op.text).toBeTruthy()
+            expect(op.marker).toBeTruthy()
           }
         }
       }
@@ -473,6 +496,114 @@ describe('Preset Configurations', () => {
 
   it('blank should have no integrations', () => {
     expect(presets.blank).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// RequiredOpMatchError — the required-match contract (cross-model review
+// HIGH finding on the P-B7 ops): a `required: true` op that matches nothing
+// must fail the whole run loudly, not silently leave a broken tree.
+// ---------------------------------------------------------------------------
+
+describe('RequiredOpMatchError (required-match contract)', () => {
+  it('applyOpsToText throws when a required op matches nothing', () => {
+    const src = 'export function foo() {\n  return 1\n}\n'
+    expect(() =>
+      applyOpsToText(src, [
+        {
+          kind: 'removeVariableStatement',
+          name: 'doesNotExist',
+          required: true,
+        },
+      ])
+    ).toThrow(RequiredOpMatchError)
+  })
+
+  it('the thrown error names the op and hints at drift', () => {
+    const src = 'export function foo() {\n  return 1\n}\n'
+    expect(() =>
+      applyOpsToText(src, [
+        {
+          kind: 'removeImport',
+          specifier: '@/does/not/exist',
+          required: true,
+        },
+      ])
+    ).toThrow(/drifted.*removeImport '@\/does\/not\/exist'/is)
+  })
+
+  it('a required op that DOES match does not throw', () => {
+    const src = 'const foo = 1\nexport function bar() {\n  return foo\n}\n'
+    const result = applyOpsToText(src, [
+      { kind: 'removeVariableStatement', name: 'foo', required: true },
+    ])
+    expect(result).not.toContain('const foo')
+  })
+
+  it('a non-required op still silently no-ops on a miss (legacy semantics preserved)', () => {
+    const src = 'export function foo() {\n  return 1\n}\n'
+    const result = applyOpsToText(src, [
+      { kind: 'removeVariableStatement', name: 'doesNotExist' },
+    ])
+    expect(result).toBe(src)
+  })
+
+  // The exact scenario the finding describes: "a future rename moves
+  // getCmsRoutes" — proven against the REAL sanity bundle ops and the REAL
+  // (mutated) source, not a synthetic fixture.
+  it('drifted fixture: renaming getCmsRoutes makes the sanity lib/seo/routes.ts strip fail loudly', () => {
+    const content = sourceFiles['lib/seo/routes.ts']
+    const bundle = INTEGRATION_BUNDLES.sanity
+    const transform = bundle?.codeTransforms.find(
+      (t) => t.file === 'lib/seo/routes.ts'
+    )
+    if (!(content && transform)) return
+
+    const drifted = content.replaceAll('getCmsRoutes', 'getCMSRoutes')
+
+    expect(() => applyOpsToText(drifted, transform.ops)).toThrow(
+      RequiredOpMatchError
+    )
+    // Sanity-check the test itself: the un-drifted file must still strip cleanly.
+    expect(() => applyOpsToText(content, transform.ops)).not.toThrow()
+  })
+
+  // The other scenario the finding names: "the revalidate try-block shape
+  // drifts" — proven against the real shared-file ops.
+  it('drifted fixture: a restructured revalidate try-block makes the sanity strip fail loudly', () => {
+    const content = sourceFiles['app/api/revalidate/route.ts']
+    const bundle = INTEGRATION_BUNDLES.sanity
+    const transform = bundle?.codeTransforms.find(
+      (t) => t.file === 'app/api/revalidate/route.ts'
+    )
+    if (!(content && transform)) return
+
+    const drifted = content.replace(
+      'SANITY_REVALIDATE_SECRET',
+      'SANITY_SECRET_V2'
+    )
+
+    expect(() => applyOpsToText(drifted, transform.ops)).toThrow(
+      RequiredOpMatchError
+    )
+    expect(() => applyOpsToText(content, transform.ops)).not.toThrow()
+  })
+
+  // Mirrors bundle-installer.ts's stripAbsentIntegrationWiring downgrade:
+  // reapplying the SAME required ops (with `required` forced to false) to
+  // source that already had them applied once must never throw — that's
+  // the expected idempotent no-op, not drift.
+  it('downgrading required to false (stripAbsentIntegrationWiring-style) tolerates an already-lean file', () => {
+    const content = sourceFiles['lib/seo/routes.ts']
+    const bundle = INTEGRATION_BUNDLES.sanity
+    const transform = bundle?.codeTransforms.find(
+      (t) => t.file === 'lib/seo/routes.ts'
+    )
+    if (!(content && transform)) return
+
+    const lean = applyOpsToText(content, transform.ops)
+    const downgraded = transform.ops.map((op) => ({ ...op, required: false }))
+    expect(() => applyOpsToText(lean, downgraded)).not.toThrow()
   })
 })
 
@@ -1209,4 +1340,111 @@ describe('replaceAnchoredText (doc patching)', () => {
     expect(text).not.toContain(anchor)
     expect(text).toContain('Cache Components is disabled in this project')
   })
+})
+
+// ---------------------------------------------------------------------------
+// P-C3 regression — a kept bundle's dependency pins must survive selfPrune's
+// package.json write.
+//
+// `setupAddIntegrations` (step 8 of `setup()`) calls `addDependencies` per
+// kept bundle, which read-modify-writes package.json on disk to pin the
+// bundle's dependency versions. `selfPrune` (step 11) used to reuse the
+// step-5 in-memory `pkg` object — read from disk BEFORE step 8 ran — and
+// write IT back to disk, silently reverting every pin `setupAddIntegrations`
+// had just written. `--keep sanity` would report "N dependencies pinned"
+// while package.json on disk ended up with none of them, and the resulting
+// `bun install && bun run build` failed on module-not-found.
+//
+// This exercises the REAL script end-to-end (not just its exported helpers):
+// a throwaway rsync copy of the repo (node_modules symlinked, matching the
+// manual acceptance procedure), run non-interactively with --skip-install
+// (no network needed — this only proves the on-disk package.json is
+// correct, not that `bun install`/`bun run build` succeed; that's covered
+// by the manual acceptance procedure in the PR description).
+// ---------------------------------------------------------------------------
+
+describe("P-C3 regression: kept bundle deps survive selfPrune's package.json write", () => {
+  it('--keep sanity pins sanity deps to disk through a full (non-dry) run', async () => {
+    const tmpRoot = await mkdtemp(join(tmpdir(), 'satus-fullrun-'))
+    try {
+      const rsync = Bun.spawnSync([
+        'rsync',
+        '-a',
+        '--exclude',
+        'node_modules',
+        '--exclude',
+        '.next',
+        '--exclude',
+        '.git',
+        `${projectRoot}/`,
+        `${tmpRoot}/`,
+      ])
+      expect(rsync.exitCode).toBe(0)
+
+      // Symlink the nearest real node_modules so the copy can run bun
+      // scripts, mirroring the manual acceptance procedure. Walk up from
+      // projectRoot: a git-worktree checkout (as used by this harness) has
+      // no node_modules of its own and resolves via the main checkout's —
+      // Bun also falls back to its global install cache when no
+      // node_modules is found at all, so this is a best-effort speed-up,
+      // not a hard requirement.
+      let nodeModulesSource: string | undefined
+      for (let dir = projectRoot; dir !== dirname(dir); dir = dirname(dir)) {
+        const candidate = join(dir, 'node_modules')
+        if (await pathExists(candidate)) {
+          nodeModulesSource = candidate
+          break
+        }
+      }
+      if (nodeModulesSource) {
+        await symlink(nodeModulesSource, join(tmpRoot, 'node_modules'))
+      }
+
+      const proc = Bun.spawnSync(
+        [
+          'bun',
+          'run',
+          'lib/scripts/setup-project.ts',
+          '--keep',
+          'sanity',
+          '--yes',
+          '--skip-install',
+        ],
+        { cwd: tmpRoot, stdout: 'pipe', stderr: 'pipe' }
+      )
+
+      if (proc.exitCode !== 0) {
+        console.error(proc.stdout.toString())
+        console.error(proc.stderr.toString())
+      }
+      expect(proc.exitCode).toBe(0)
+
+      const pkg = JSON.parse(
+        await Bun.file(join(tmpRoot, 'package.json')).text()
+      ) as {
+        dependencies?: Record<string, string>
+        devDependencies?: Record<string, string>
+      }
+
+      for (const dep of [
+        '@portabletext/react',
+        '@sanity/asset-utils',
+        '@sanity/image-url',
+        'next-sanity',
+      ]) {
+        expect(
+          pkg.dependencies?.[dep],
+          `missing dependency "${dep}"`
+        ).toBeTruthy()
+      }
+      for (const devDep of ['@sanity/vision', 'sanity']) {
+        expect(
+          pkg.devDependencies?.[devDep],
+          `missing devDependency "${devDep}"`
+        ).toBeTruthy()
+      }
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true })
+    }
+  }, 60000)
 })

--- a/lib/scripts/setup-project.ts
+++ b/lib/scripts/setup-project.ts
@@ -689,6 +689,32 @@ export const CACHE_COMPONENTS_DISABLE_TRANSFORM: CodeTransform = {
 }
 
 /**
+ * app/llms.txt/route.ts's `buildBody()` has its own `'use cache'` directive,
+ * independent of any CMS integration — it caches the plain-text response
+ * builder, not a Sanity fetch. `'use cache'` is a hard Next.js compile error
+ * once Cache Components is disabled, so this must be stripped in the same
+ * pass as the next.config.ts flip (P-B7: a blank/no-CMS build failed with
+ * "please enable the feature flag `cacheComponents`" pointing at this file).
+ *
+ * `required: true`: `setupCacheComponentsOptOut` applies this exactly once
+ * per setup() run, against the pristine file — a zero-match here can only
+ * mean `buildBody` was renamed or its directive moved, not a legitimate
+ * idempotent re-application (unlike the bundle-owned ops in
+ * integration-bundles.ts, this one is never touched by
+ * stripAbsentIntegrationWiring).
+ */
+export const CACHE_COMPONENTS_LLMS_TXT_TRANSFORM: CodeTransform = {
+  file: 'app/llms.txt/route.ts',
+  ops: [
+    {
+      kind: 'removeUseCacheDirective',
+      functionName: 'buildBody',
+      required: true,
+    },
+  ],
+}
+
+/**
  * Anchored doc-sentence replacements so a fork's docs don't claim Cache
  * Components is enabled after setup just disabled it. Each `anchor` is
  * matched as an exact substring; when absent (doc since reworded), the file
@@ -764,7 +790,7 @@ const setupCacheComponentsOptOut = async (
   s.start('Disabling Cache Components (no CMS/storefront kept)...')
 
   const { failures } = await applyCodeTransforms(
-    [CACHE_COMPONENTS_DISABLE_TRANSFORM],
+    [CACHE_COMPONENTS_DISABLE_TRANSFORM, CACHE_COMPONENTS_LLMS_TXT_TRANSFORM],
     dryRun
   )
 
@@ -953,13 +979,16 @@ const selfPrune = async (
  *  10. setupCacheComponentsOptOut — when the final kept set has neither
  *      sanity nor shopify, flip `cacheComponents` off in next.config.ts and
  *      patch the docs that claim it's enabled. No-op otherwise.
- *  11. selfPrune — delete setup files (including this script) and mutate
- *      pkg.scripts in-memory, THEN a second package.json write to persist
- *      the scripts removal. This is deliberately the LAST mutating step:
- *      running it only after setupAddIntegrations has completed
- *      successfully means any failure in steps 3–8 leaves
- *      lib/scripts/setup-project.ts (and its package.json script entry)
- *      intact, so the run can simply be repeated (H8).
+ *  11. selfPrune — re-reads package.json from disk (P-C3: step 8's
+ *      `addDependencies` writes dependency pins straight to disk, which the
+ *      step-5 `pkg` object never observes; reusing that stale object here
+ *      would silently revert those pins), then deletes setup files
+ *      (including this script) and mutates the freshly-read pkg.scripts,
+ *      THEN a second package.json write to persist the scripts removal.
+ *      This is deliberately the LAST mutating step: running it only after
+ *      setupAddIntegrations has completed successfully means any failure in
+ *      steps 3–8 leaves lib/scripts/setup-project.ts (and its package.json
+ *      script entry) intact, so the run can simply be repeated (H8).
  *  12. bun install (unless --skip-install). Non-fatal on failure (M5): a
  *      registry/offline error is reported and surfaced to the caller via
  *      the returned `installFailed` flag, but does not undo or block the
@@ -1062,9 +1091,21 @@ const setup = async (
   // 11. Self-prune: delete setup files (including this script), mutate
   //     pkg.scripts in-memory, and persist that with a second package.json
   //     write. Deliberately last — see the docstring above.
-  await selfPrune(pkg, dryRun)
+  //
+  //     Re-read package.json from disk here rather than reusing the `pkg`
+  //     object from step 5: `setupAddIntegrations` (step 8) calls
+  //     `addDependencies` per kept bundle, which does its own
+  //     read-modify-write cycle against package.json on disk to pin each
+  //     kept integration's dependency versions. The step-5 `pkg` object
+  //     predates that write and knows nothing about it — writing it back
+  //     here would silently revert every dependency pin `setupAddIntegrations`
+  //     just made (P-C3: `--keep sanity` reported "N dependencies pinned"
+  //     while package.json on disk ended up with none of them, and the
+  //     resulting build failed on module-not-found).
+  const prunePkg = (await Bun.file(pkgPath).json()) as PackageJson
+  await selfPrune(prunePkg, dryRun)
   if (!dryRun) {
-    await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
+    await Bun.write(pkgPath, `${JSON.stringify(prunePkg, null, 2)}\n`)
   }
 
   // 12. Run bun install to update the lockfile. Non-fatal: an offline /


### PR DESCRIPTION
## What this does
Two Highs from the process audit plus a High from cross-model review, all reproduced:

- **P-C3**: \`selfPrune\` wrote a stale early-read package.json back over \`addDependencies\`' pins — \`--keep sanity\` claimed "6 dependencies pinned" while the disk had none, then failed with 24 module-not-found errors. Now re-reads before writing.
- **P-B7**: the blank strip deleted sanity modules that \`lib/seo/routes.ts\`, the llms route, the revalidate route, and \`lib/dev/stats\` still import (the old config crash aborted builds before webpack ever surfaced this). New AST transform ops strip those consumers per-bundle, with the revalidate route split into per-owner transforms to avoid cross-contamination.
- **Review High**: the op runner silently no-ops on drifted source — the new load-bearing ops now carry \`required: true\` and a zero-match run FAILS loudly before self-prune (recoverable by design), with drifted-fixture tests proving it. Legit re-application on already-lean files (boutique preset) downgrades required — found and covered.

## Test Plan
- [x] Blank preset: setup → install → build exit 0
- [x] \`--keep sanity\`: build exit 0, deps present on disk
- [x] Boutique preset (double-touch scenario): build exit 0
- [x] Drift fixtures: required ops throw pre-self-prune