### PR TITLE
fix(scripts): make bun run check green after a real setup:project run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,8 @@ plans
 
 # prepare-handoff backup — created by `bun run handoff` when swapping README
 README.original.md
+
+# setup:project --skip-install → prepare.ts handoff (P-B2) — see
+# PENDING_FORMAT_MARKER in lib/scripts/utils.ts; deleted by prepare.ts on the
+# next `bun install`, but ignore it in case that never runs.
+.setup-project-pending-format.json

--- a/lib/scripts/ast-transforms/index.ts
+++ b/lib/scripts/ast-transforms/index.ts
@@ -270,12 +270,22 @@ export interface TransformFailure {
  * leaving a broken tree (an import removed, the code that used it still
  * there) — that must stop the run before `setup()` reaches self-prune, not
  * just get reported alongside everything else at the end.
+ *
+ * `changedFiles` (relative paths, deduped, one entry per transform that
+ * actually wrote — a single file can appear once even if two transforms in
+ * `transforms` both touch it) lets callers reformat exactly the files this
+ * run modified afterward (P-B2), instead of the whole repo.
  */
 export async function applyCodeTransforms(
   transforms: CodeTransform[],
   dryRun: boolean
-): Promise<{ changes: number; failures: TransformFailure[] }> {
+): Promise<{
+  changes: number
+  changedFiles: string[]
+  failures: TransformFailure[]
+}> {
   let totalChanges = 0
+  const changedFiles = new Set<string>()
   const failures: TransformFailure[] = []
 
   for (const transform of transforms) {
@@ -293,6 +303,7 @@ export async function applyCodeTransforms(
           await Bun.write(fullPath, transformed)
         }
         totalChanges++
+        changedFiles.add(transform.file)
       }
     } catch (error) {
       if (error instanceof RequiredOpMatchError) {
@@ -305,5 +316,5 @@ export async function applyCodeTransforms(
     }
   }
 
-  return { changes: totalChanges, failures }
+  return { changes: totalChanges, changedFiles: [...changedFiles], failures }
 }

--- a/lib/scripts/bundle-installer.ts
+++ b/lib/scripts/bundle-installer.ts
@@ -294,6 +294,7 @@ export const installBundle = async (
   depsAdded: string[]
   overwriteSkipped: string[]
   depsMissing: string[]
+  changedFiles: string[]
   failures: TransformFailure[]
 }> => {
   const details: string[] = []
@@ -333,6 +334,7 @@ export const installBundle = async (
     depsAdded: deps.added,
     overwriteSkipped: overwrite.skipped,
     depsMissing: deps.missing,
+    changedFiles: transformResult.changedFiles,
     failures: transformResult.failures,
   }
 }
@@ -367,7 +369,11 @@ export const installBundle = async (
 export const stripAbsentIntegrationWiring = async (
   installedOrAdded: Set<string> | string[],
   dryRun: boolean
-): Promise<{ changes: number; failures: TransformFailure[] }> => {
+): Promise<{
+  changes: number
+  changedFiles: string[]
+  failures: TransformFailure[]
+}> => {
   const skipSet =
     installedOrAdded instanceof Set
       ? installedOrAdded
@@ -380,7 +386,9 @@ export const stripAbsentIntegrationWiring = async (
     stripTransforms.push(...bundle.codeTransforms)
   }
 
-  if (stripTransforms.length === 0) return { changes: 0, failures: [] }
+  if (stripTransforms.length === 0) {
+    return { changes: 0, changedFiles: [], failures: [] }
+  }
 
   const nonRequiredTransforms = stripTransforms.map((transform) => ({
     ...transform,

--- a/lib/scripts/prepare.ts
+++ b/lib/scripts/prepare.ts
@@ -1,15 +1,155 @@
 /**
- * `prepare` entry point — installs the lefthook git hooks.
+ * `prepare` entry point — installs the lefthook git hooks, and finishes any
+ * `setup:project` run that deferred formatting + COMPONENTS.md regeneration
+ * because it ran with `--skip-install` (P-B2): oxfmt can't run until `bun
+ * install` has populated node_modules (its own `oxfmt.config.ts` imports the
+ * `oxfmt` package for typed config authoring, which doesn't resolve on a
+ * bare `--skip-install` tree), and generate-manifest.ts resolves actual type
+ * information via ts-morph, so regenerating it before that install can
+ * produce a manifest that doesn't match the real, post-install types. `bun
+ * install` always runs `prepare` afterward (unless `--ignore-scripts`), so
+ * this is the first reliable point in that flow to finish the job — see
+ * `PENDING_FORMAT_MARKER` in `./utils.ts`.
+ *
+ * The marker handoff is defensive by design (cross-model review finding):
+ *   - A malformed/partial marker (bad JSON, missing `files`) is warned about
+ *     and deleted, never thrown — an uncaught exception here would crash
+ *     `prepare.ts` before the marker is removed, and since `bun install`
+ *     always re-runs `prepare`, that would brick every future `bun install`
+ *     in the project on the same crash, forever.
+ *   - Listed files that no longer exist (moved/deleted since setup ran) are
+ *     skipped with a note instead of failing oxfmt on a missing path.
+ *   - On a format/manifest step failure, the marker is KEPT (with its
+ *     `attempts` counter incremented) so the NEXT `bun install` retries,
+ *     and the exact manual recovery commands are printed either way. Capped
+ *     at `PENDING_FORMAT_MAX_ATTEMPTS`: past that, the marker is deleted
+ *     with a loud instruction instead of retrying forever.
  *
  * In a linked worktree (`git worktree add`), the repo config is shared with the
  * main checkout and `core.hooksPath` already points at its `.git/hooks`, so the
  * hooks apply here without installing anything — and `lefthook install` refuses
  * to run against that path and fails the whole `bun install`. Skip it instead.
  * Outside a git repo (exported archive, CI cache restore) there is nothing to
- * install into, so that skips too.
+ * install into, so that skips too. Neither skip affects the pending-format
+ * check above, which runs regardless.
  */
 
+import { unlink } from 'node:fs/promises'
 import { resolve } from 'node:path'
+
+import {
+  PENDING_FORMAT_MARKER,
+  PENDING_FORMAT_MAX_ATTEMPTS,
+  type PendingFormatMarker,
+  pathExists,
+  resolvePath,
+} from './utils'
+
+const markerPath = resolvePath(PENDING_FORMAT_MARKER)
+
+/** Type-guards a parsed JSON value into a `PendingFormatMarker`. */
+function isValidMarker(value: unknown): value is PendingFormatMarker {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<PendingFormatMarker>
+  if (!Array.isArray(candidate.files)) return false
+  if (!candidate.files.every((file) => typeof file === 'string')) return false
+  if (
+    candidate.attempts !== undefined &&
+    typeof candidate.attempts !== 'number'
+  ) {
+    return false
+  }
+  return true
+}
+
+const deleteMarker = async (): Promise<void> => {
+  try {
+    await unlink(markerPath)
+  } catch {
+    // Already gone (or unremovable) — nothing more to do.
+  }
+}
+
+if (await pathExists(markerPath)) {
+  let marker: PendingFormatMarker | undefined
+  try {
+    const raw: unknown = await Bun.file(markerPath).json()
+    if (isValidMarker(raw)) marker = raw
+  } catch {
+    // Malformed JSON — `marker` stays undefined, handled below.
+  }
+
+  if (!marker) {
+    console.warn(
+      `prepare: ${PENDING_FORMAT_MARKER} is malformed — ignoring and deleting it. If \`setup:project --skip-install\` just ran, finish manually: bun run format <files> && bun run generate:manifest`
+    )
+    await deleteMarker()
+  } else {
+    const attempts = (marker.attempts ?? 0) + 1
+
+    // Skip files that no longer exist since setup ran, rather than failing
+    // oxfmt on a missing path.
+    const existingFiles: string[] = []
+    for (const file of marker.files) {
+      if (await pathExists(resolvePath(file))) {
+        existingFiles.push(file)
+      } else {
+        console.warn(`prepare: ${file} no longer exists — skipping`)
+      }
+    }
+
+    let ok = true
+
+    if (existingFiles.length > 0) {
+      console.log(
+        `prepare: finishing a deferred \`setup:project --skip-install\` run — formatting ${existingFiles.length} file${existingFiles.length === 1 ? '' : 's'}`
+      )
+      const format = Bun.spawnSync(['bun', 'run', 'format', ...existingFiles], {
+        stdout: 'inherit',
+        stderr: 'inherit',
+      })
+      if (format.exitCode !== 0) {
+        ok = false
+      }
+    }
+
+    console.log('prepare: regenerating COMPONENTS.md')
+    const manifest = Bun.spawnSync(['bun', 'run', 'generate:manifest'], {
+      stdout: 'inherit',
+      stderr: 'inherit',
+    })
+    if (manifest.exitCode !== 0) {
+      ok = false
+    }
+
+    if (ok) {
+      await deleteMarker()
+    } else {
+      const manualCommand =
+        existingFiles.length > 0
+          ? `bun run format ${existingFiles.join(' ')} && bun run generate:manifest`
+          : 'bun run generate:manifest'
+
+      if (attempts >= PENDING_FORMAT_MAX_ATTEMPTS) {
+        console.warn(
+          `prepare: giving up after ${attempts} attempt${attempts === 1 ? '' : 's'} — deleting the marker so future \`bun install\` runs stop retrying. Finish manually: ${manualCommand}`
+        )
+        await deleteMarker()
+      } else {
+        // Keep the marker (with the attempt count bumped) so the next
+        // `bun install` retries — never brick install itself on a failure
+        // here; this script still finishes and lefthook still runs below.
+        await Bun.write(
+          markerPath,
+          `${JSON.stringify({ files: existingFiles, attempts }, null, 2)}\n`
+        )
+        console.warn(
+          `prepare: will retry on the next \`bun install\` (attempt ${attempts}/${PENDING_FORMAT_MAX_ATTEMPTS}). To finish now instead: ${manualCommand}`
+        )
+      }
+    }
+  }
+}
 
 const git = Bun.spawnSync([
   'git',

--- a/lib/scripts/setup-project.test.ts
+++ b/lib/scripts/setup-project.test.ts
@@ -34,7 +34,13 @@ import {
   shouldDisableCacheComponents,
   shouldSkipConfirm,
 } from './setup-project'
-import { getFlagValue, pathExists, projectRoot } from './utils'
+import {
+  getFlagValue,
+  PENDING_FORMAT_MARKER,
+  PENDING_FORMAT_MAX_ATTEMPTS,
+  pathExists,
+  projectRoot,
+} from './utils'
 
 // ---------------------------------------------------------------------------
 // Source file fixtures — loaded once, never written to disk
@@ -1442,6 +1448,178 @@ describe("P-C3 regression: kept bundle deps survive selfPrune's package.json wri
           pkg.devDependencies?.[devDep],
           `missing devDependency "${devDep}"`
         ).toBeTruthy()
+      }
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true })
+    }
+  }, 60000)
+})
+
+// ---------------------------------------------------------------------------
+// prepare.ts's pending-format marker handling (cross-model review MEDIUM
+// finding): the marker is unvalidated — a malformed/partial marker used to
+// throw BEFORE unlinking, bricking every subsequent `bun install` on the
+// same crash forever; and a format/manifest failure deleted the marker
+// anyway, losing the retry.
+// ---------------------------------------------------------------------------
+
+describe('prepare.ts pending-format marker (defensive handling)', () => {
+  const setupCopy = async (): Promise<string> => {
+    const tmpRoot = await mkdtemp(join(tmpdir(), 'satus-prepare-'))
+    const rsync = Bun.spawnSync([
+      'rsync',
+      '-a',
+      '--exclude',
+      'node_modules',
+      '--exclude',
+      '.next',
+      '--exclude',
+      '.git', // no .git → prepare.ts's lefthook step always no-ops cleanly
+      `${projectRoot}/`,
+      `${tmpRoot}/`,
+    ])
+    expect(rsync.exitCode).toBe(0)
+
+    // Symlink the nearest real node_modules so `bun run format` (oxfmt) can
+    // actually run — same rationale as the P-C3 test above.
+    for (let dir = projectRoot; dir !== dirname(dir); dir = dirname(dir)) {
+      const candidate = join(dir, 'node_modules')
+      if (await pathExists(candidate)) {
+        await symlink(candidate, join(tmpRoot, 'node_modules'))
+        break
+      }
+    }
+
+    return tmpRoot
+  }
+
+  const runPrepare = (cwd: string) =>
+    Bun.spawnSync(['bun', 'lib/scripts/prepare.ts'], {
+      cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+  it('a malformed marker (invalid JSON) is deleted, not thrown — install survives', async () => {
+    const tmpRoot = await setupCopy()
+    try {
+      const markerPath = join(tmpRoot, PENDING_FORMAT_MARKER)
+      await Bun.write(markerPath, '{ this is not valid json')
+
+      const proc = runPrepare(tmpRoot)
+
+      // Never crashes: prepare.ts must run to completion regardless of a
+      // corrupt marker, or `bun install` (which always runs `prepare`)
+      // would fail forever on the exact same crash.
+      expect(proc.exitCode).toBe(0)
+      expect(
+        (proc.stdout.toString() + proc.stderr.toString()).toLowerCase()
+      ).toContain('malformed')
+      expect(await pathExists(markerPath)).toBe(false)
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true })
+    }
+  }, 30000)
+
+  it('a marker missing the required "files" array is deleted, not thrown', async () => {
+    const tmpRoot = await setupCopy()
+    try {
+      const markerPath = join(tmpRoot, PENDING_FORMAT_MARKER)
+      await Bun.write(markerPath, `${JSON.stringify({ notFiles: 'oops' })}\n`)
+
+      const proc = runPrepare(tmpRoot)
+
+      expect(proc.exitCode).toBe(0)
+      expect(await pathExists(markerPath)).toBe(false)
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true })
+    }
+  }, 30000)
+
+  it('a listed file that no longer exists is skipped with a note, not a failure', async () => {
+    const tmpRoot = await setupCopy()
+    try {
+      const markerPath = join(tmpRoot, PENDING_FORMAT_MARKER)
+      await Bun.write(
+        markerPath,
+        `${JSON.stringify({ files: ['lib/scripts/this-file-does-not-exist.ts'] })}\n`
+      )
+
+      const proc = runPrepare(tmpRoot)
+
+      expect(proc.exitCode).toBe(0)
+      expect(
+        (proc.stdout.toString() + proc.stderr.toString()).toLowerCase()
+      ).toContain('no longer exists')
+      // Nothing left to retry — the marker is cleaned up.
+      expect(await pathExists(markerPath)).toBe(false)
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true })
+    }
+  }, 30000)
+
+  it('a real marker is finished successfully: files formatted, manifest regenerated, marker deleted', async () => {
+    const tmpRoot = await setupCopy()
+    try {
+      const markerPath = join(tmpRoot, PENDING_FORMAT_MARKER)
+      // A real, tracked file — formatting it is a genuine (harmless) no-op
+      // since it's already correctly formatted.
+      await Bun.write(
+        markerPath,
+        `${JSON.stringify({ files: ['lib/scripts/utils.ts'] })}\n`
+      )
+
+      const proc = runPrepare(tmpRoot)
+
+      if (proc.exitCode !== 0) {
+        console.error(proc.stdout.toString())
+        console.error(proc.stderr.toString())
+      }
+      expect(proc.exitCode).toBe(0)
+      expect(await pathExists(markerPath)).toBe(false)
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true })
+    }
+  }, 30000)
+
+  it('a repeatedly-failing step keeps the marker (with attempts incrementing) up to the cap, then gives up loudly instead of retrying forever', async () => {
+    const tmpRoot = await setupCopy()
+    try {
+      // Force the format step to fail deterministically.
+      const pkgPath = join(tmpRoot, 'package.json')
+      const pkg = JSON.parse(await Bun.file(pkgPath).text()) as {
+        scripts: Record<string, string>
+      }
+      pkg.scripts.format = 'exit 1'
+      await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
+
+      const markerPath = join(tmpRoot, PENDING_FORMAT_MARKER)
+      await Bun.write(
+        markerPath,
+        `${JSON.stringify({ files: ['lib/scripts/utils.ts'] })}\n`
+      )
+
+      // Run PENDING_FORMAT_MAX_ATTEMPTS times: every run but the last keeps
+      // the marker with `attempts` incremented; the last one gives up and
+      // deletes it instead of looping forever.
+      for (let attempt = 1; attempt <= PENDING_FORMAT_MAX_ATTEMPTS; attempt++) {
+        const proc = runPrepare(tmpRoot)
+        expect(proc.exitCode).toBe(0) // never bricks install, even on failure
+
+        if (attempt < PENDING_FORMAT_MAX_ATTEMPTS) {
+          expect(await pathExists(markerPath)).toBe(true)
+          const marker = JSON.parse(await Bun.file(markerPath).text()) as {
+            attempts?: number
+          }
+          expect(marker.attempts).toBe(attempt)
+          const output = proc.stdout.toString() + proc.stderr.toString()
+          expect(output).toContain('will retry')
+          expect(output).toContain('bun run format')
+        } else {
+          expect(await pathExists(markerPath)).toBe(false)
+          const output = proc.stdout.toString() + proc.stderr.toString()
+          expect(output.toLowerCase()).toContain('giving up')
+        }
       }
     } finally {
       await rm(tmpRoot, { recursive: true, force: true })

--- a/lib/scripts/setup-project.ts
+++ b/lib/scripts/setup-project.ts
@@ -55,6 +55,8 @@ import {
   getFlagValue,
   parseCliFlags,
   pathExists,
+  PENDING_FORMAT_MARKER,
+  type PendingFormatMarker,
   projectRoot,
   removeDir,
   removeFile,
@@ -283,6 +285,95 @@ const ensureNextTypeStub = async (dryRun: boolean): Promise<void> => {
 }
 
 // ---------------------------------------------------------------------------
+// Post-run cleanup (P-B2): the AST-transform engine's output is functionally
+// correct but not always oxfmt-clean (a blank line off in a handful of
+// files), and COMPONENTS.md isn't self-updating. Both run as the final steps
+// of a real (non-dry) run so `bun run check` is green immediately after
+// setup, without a human having to notice and run them manually.
+//
+// Both need a real `bun install` to have already happened:
+//   - oxfmt needs `bun install` to have populated node_modules — its own
+//     `oxfmt.config.ts` (a typed config, not `.oxfmtrc.json`) imports the
+//     `oxfmt` package for `defineConfig`, which fails to resolve on a bare
+//     `--skip-install` tree even via `bunx` (unlike a plain module import,
+//     which Bun resolves from its global cache regardless of a local
+//     node_modules).
+//   - generate-manifest.ts resolves actual TYPE information via ts-morph
+//     (not just source text), so its output depends on which package
+//     versions are installed — regenerating it against a pre-install
+//     node_modules can produce a manifest that immediately fails
+//     `manifest:check` once the real install lands (an inferred type like
+//     `ZodEmail` reads as `any` against the wrong/stale zod install).
+//
+// When install already ran (`!skipInstall`), both run immediately — the
+// filesystem state right after `setup()` is exactly what `bun run check`
+// will see. When `--skip-install` was passed, both are deferred to a
+// `PENDING_FORMAT_MARKER` file that `prepare.ts` picks up and finishes the
+// next time `bun install` runs `prepare` (its normal lifecycle hook) — the
+// first point in that flow where both are guaranteed to work.
+// ---------------------------------------------------------------------------
+
+/**
+ * Run `bun run format` (oxfmt) over exactly the files this run's AST
+ * transforms modified — never the whole repo. No-op when nothing changed.
+ */
+const formatChangedFiles = async (files: string[]): Promise<void> => {
+  if (files.length === 0) return
+
+  const s = p.spinner()
+  const label = `${files.length} transformed file${files.length > 1 ? 's' : ''}`
+  s.start(`Formatting ${label}...`)
+  try {
+    await Bun.$`bun run format ${files}`.quiet()
+    s.stop(`Formatted ${label}`)
+  } catch (error) {
+    s.stop(`Formatting ${label} failed — run \`bun run format\` manually`)
+    p.log.warn(error instanceof Error ? error.message : String(error))
+  }
+}
+
+/**
+ * Regenerate COMPONENTS.md via the existing `generate:manifest` script so it
+ * reflects the strip/re-add's final component set.
+ */
+const regenerateManifest = async (): Promise<void> => {
+  const s = p.spinner()
+  s.start('Regenerating COMPONENTS.md...')
+  try {
+    await Bun.$`bun run generate:manifest`.quiet()
+    s.stop('Regenerated COMPONENTS.md')
+  } catch (error) {
+    s.stop(
+      'Regenerating COMPONENTS.md failed — run `bun run generate:manifest` manually'
+    )
+    p.log.warn(error instanceof Error ? error.message : String(error))
+  }
+}
+
+/**
+ * Persist the still-unformatted file list so `prepare.ts` can finish
+ * formatting AND regenerate COMPONENTS.md once `bun install` actually runs
+ * (see the module docstring above). Always written on a real, non-dry
+ * --skip-install run — even with an empty `files` list — because the
+ * manifest regeneration `prepare.ts` also performs needs deferring
+ * regardless of whether any AST transform changed a file.
+ */
+const writePendingFormatMarker = async (files: string[]): Promise<void> => {
+  const marker: PendingFormatMarker = { files }
+  await Bun.write(
+    resolvePath(PENDING_FORMAT_MARKER),
+    `${JSON.stringify(marker, null, 2)}\n`
+  )
+  const formatNote =
+    files.length > 0
+      ? `${files.length} file${files.length === 1 ? '' : 's'} formatted and `
+      : ''
+  p.log.step(
+    `Deferred to the next \`bun install\`: ${formatNote}COMPONENTS.md regenerated (--skip-install was passed)`
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Preflight (H8): validate before any mutation begins
 // ---------------------------------------------------------------------------
 
@@ -432,7 +523,12 @@ const setupSnapshot = async (
 const setupLean = async (
   pkg: PackageJson,
   dryRun: boolean
-): Promise<{ deps: number; devDeps: number; failures: TransformFailure[] }> => {
+): Promise<{
+  deps: number
+  devDeps: number
+  changedFiles: string[]
+  failures: TransformFailure[]
+}> => {
   const integrationNames = getIntegrationNames()
   const s = p.spinner()
 
@@ -445,10 +541,12 @@ const setupLean = async (
 
   // Apply code transformations BEFORE removing folders
   let failures: TransformFailure[] = []
+  let changedFiles: string[] = []
   if (allCodeTransforms.length > 0) {
     s.start('Stripping integrations (code transforms)...')
     const transformResult = await applyCodeTransforms(allCodeTransforms, dryRun)
     failures = transformResult.failures
+    changedFiles = transformResult.changedFiles
     s.stop(
       transformResult.changes > 0
         ? `Applied ${transformResult.changes} code transformations`
@@ -542,7 +640,7 @@ const setupLean = async (
     )
   }
 
-  return { deps: totalDeps, devDeps: totalDevDeps, failures }
+  return { deps: totalDeps, devDeps: totalDevDeps, changedFiles, failures }
 }
 
 /**
@@ -563,8 +661,8 @@ const setupAddIntegrations = async (
   keepIntegrations: RemovableId[],
   source: PayloadSource,
   dryRun: boolean
-): Promise<{ failures: TransformFailure[] }> => {
-  if (keepIntegrations.length === 0) return { failures: [] }
+): Promise<{ changedFiles: string[]; failures: TransformFailure[] }> => {
+  if (keepIntegrations.length === 0) return { changedFiles: [], failures: [] }
 
   const s = p.spinner()
 
@@ -578,6 +676,7 @@ const setupAddIntegrations = async (
   // is not needed here — the snapshot already has all files).
   const addedIntegrationIds = new Set<RemovableId>()
   const failures: TransformFailure[] = []
+  const changedFiles = new Set<string>()
 
   for (const id of keepIntegrations) {
     const bundle = getBundle(id)
@@ -585,16 +684,16 @@ const setupAddIntegrations = async (
 
     s.start(`Re-adding ${bundle.name}...`)
 
-    const { details, failures: bundleFailures } = await installBundle(
-      source,
-      bundle,
-      payloadPkg,
-      {
-        dryRun,
-        force: true, // we just stripped everything — always overwrite
-      }
-    )
+    const {
+      details,
+      failures: bundleFailures,
+      changedFiles: bundleChangedFiles,
+    } = await installBundle(source, bundle, payloadPkg, {
+      dryRun,
+      force: true, // we just stripped everything — always overwrite
+    })
     failures.push(...bundleFailures)
+    for (const file of bundleChangedFiles) changedFiles.add(file)
 
     addedIntegrationIds.add(id)
 
@@ -611,13 +710,14 @@ const setupAddIntegrations = async (
     dryRun
   )
   failures.push(...stripResult.failures)
+  for (const file of stripResult.changedFiles) changedFiles.add(file)
   if (stripResult.changes > 0) {
     p.log.step(
       `Stripped absent-integration wiring from ${stripResult.changes} copied files`
     )
   }
 
-  return { failures }
+  return { changedFiles: [...changedFiles], failures }
 }
 
 // ---------------------------------------------------------------------------
@@ -781,15 +881,15 @@ export const isCacheComponentsDisabled = (configText: string): boolean =>
 const setupCacheComponentsOptOut = async (
   keepIntegrations: RemovableId[],
   dryRun: boolean
-): Promise<{ failures: TransformFailure[] }> => {
+): Promise<{ changedFiles: string[]; failures: TransformFailure[] }> => {
   if (!shouldDisableCacheComponents(keepIntegrations)) {
-    return { failures: [] }
+    return { changedFiles: [], failures: [] }
   }
 
   const s = p.spinner()
   s.start('Disabling Cache Components (no CMS/storefront kept)...')
 
-  const { failures } = await applyCodeTransforms(
+  const { changedFiles, failures } = await applyCodeTransforms(
     [CACHE_COMPONENTS_DISABLE_TRANSFORM, CACHE_COMPONENTS_LLMS_TXT_TRANSFORM],
     dryRun
   )
@@ -811,7 +911,7 @@ const setupCacheComponentsOptOut = async (
         error:
           'setObjectProperty found no `cacheComponents` property on `nextConfig` to flip — disable it manually (and `experimental.cachedNavigations` with it)',
       })
-      return { failures }
+      return { changedFiles, failures }
     }
   }
 
@@ -849,7 +949,7 @@ const setupCacheComponentsOptOut = async (
     'Cache Components disabled (no CMS/storefront kept) — re-enable in next.config.ts if this project adds one'
   )
 
-  return { failures }
+  return { changedFiles, failures }
 }
 
 /**
@@ -993,6 +1093,13 @@ const selfPrune = async (
  *      registry/offline error is reported and surfaced to the caller via
  *      the returned `installFailed` flag, but does not undo or block the
  *      steps above — the setup itself already succeeded by this point.
+ *  13. formatChangedFiles — run `bun run format` (oxfmt) over exactly the
+ *      files steps 6/8/10 actually modified (P-B2: the AST-transform
+ *      engine's output isn't always oxfmt-clean). Real (non-dry) runs only;
+ *      independent of --skip-install.
+ *  14. regenerateManifest — regenerate COMPONENTS.md via the existing
+ *      `generate:manifest` script so it reflects the final component set
+ *      (P-B2). Real (non-dry) runs only; independent of --skip-install.
  *
  * Returns `installFailed` (bun install failed but setup files are all
  * written) and `transformFailures` (any AST code-transform that failed —
@@ -1066,6 +1173,7 @@ const setup = async (
   //    The snapshot cleanup is in `finally` so the temp dir is always removed,
   //    even when setupAddIntegrations throws.
   let addFailures: TransformFailure[] = []
+  let addChangedFiles: string[] = []
   if (snapshot) {
     try {
       const addResult = await setupAddIntegrations(
@@ -1074,6 +1182,7 @@ const setup = async (
         dryRun
       )
       addFailures = addResult.failures
+      addChangedFiles = addResult.changedFiles
     } finally {
       // 9. Cleanup snapshot temp directory (always runs — even on failure).
       await snapshot.cleanup()
@@ -1124,6 +1233,37 @@ const setup = async (
       p.log.warn(
         `Dependency install failed (offline?). Your files are ready — run \`bun install\` manually.\n${error instanceof Error ? error.message : String(error)}`
       )
+    }
+  }
+
+  // 13. Format exactly the files this run's AST transforms touched (P-B2) —
+  //     never the whole repo.
+  // 14. Regenerate COMPONENTS.md so it reflects the final component set
+  //     (P-B2).
+  // Both are final, best-effort steps: a real (non-dry) run only. Both also
+  // need a real `bun install` to have already happened: oxfmt can't run at
+  // all on a bare --skip-install tree (see the docstring above), and
+  // generate-manifest.ts resolves actual TYPE information via ts-morph (not
+  // just source text) — its output depends on which package versions are
+  // installed, so regenerating it against a pre-install node_modules can
+  // produce a manifest that immediately fails `manifest:check` once the
+  // real install lands. When bun install just ran (above), both run
+  // immediately; when --skip-install was passed, both are deferred to
+  // `prepare.ts` (see PENDING_FORMAT_MARKER's docstring), which runs the
+  // next time `bun install` does.
+  if (!dryRun) {
+    const changedFiles = [
+      ...new Set([
+        ...leanResult.changedFiles,
+        ...addChangedFiles,
+        ...cacheResult.changedFiles,
+      ]),
+    ]
+    if (skipInstall) {
+      await writePendingFormatMarker(changedFiles)
+    } else {
+      await formatChangedFiles(changedFiles)
+      await regenerateManifest()
     }
   }
 

--- a/lib/scripts/utils.ts
+++ b/lib/scripts/utils.ts
@@ -34,6 +34,41 @@ export const pathExists = async (path: string): Promise<boolean> => {
 }
 
 // ============================================================================
+// setup:project ↔ prepare handoff (P-B2)
+// ============================================================================
+
+/**
+ * Marker file `setup-project.ts` writes when it ran with `--skip-install`
+ * (oxfmt can't format anything until `bun install` has populated
+ * node_modules — see `setup-project.ts`'s "Post-run cleanup" docstring) and
+ * `prepare.ts` reads on the next `bun install` to finish the deferred
+ * formatting. Lives here (not in setup-project.ts) because prepare.ts ships
+ * with every scaffolded project and must keep working after setup-project.ts
+ * self-prunes.
+ */
+export const PENDING_FORMAT_MARKER = '.setup-project-pending-format.json'
+
+/** Shape of `PENDING_FORMAT_MARKER`'s JSON contents. */
+export interface PendingFormatMarker {
+  files: string[]
+  /**
+   * Number of times `prepare.ts` has already tried (and failed) to finish
+   * this marker. Absent/0 on the first attempt. `prepare.ts` deletes the
+   * marker with a loud instruction once `attempts` reaches
+   * `PENDING_FORMAT_MAX_ATTEMPTS`, instead of retrying forever on every
+   * future `bun install`.
+   */
+  attempts?: number
+}
+
+/**
+ * How many times `prepare.ts` retries a failed format/manifest step before
+ * giving up and deleting `PENDING_FORMAT_MARKER` outright (with a loud,
+ * copy-pasteable manual-recovery instruction).
+ */
+export const PENDING_FORMAT_MAX_ATTEMPTS = 2
+
+// ============================================================================
 // File System Operations (Cross-platform)
 // ============================================================================
 


### PR DESCRIPTION
## What this does
After the documented happy path (\`setup:project --keep sanity\` → install), \`bun run check\` was red twice over: the AST transforms left six files a blank line off oxfmt's expectations, and COMPONENTS.md was never regenerated after strip/re-add. Process-audit finding P-B2.

Setup now tracks exactly which files it transformed and reformats only those, then regenerates the manifest. Both need a real node_modules (oxfmt's typed config and ts-morph's type inference both fail on a bare tree — the manifest one produced observably wrong output), so under \`--skip-install\` they defer via a pending marker that \`prepare.ts\` finishes on the next install. From cross-model review: the marker is malformed-proof (never bricks install), skips missing files with a note, and retries failures at most twice before giving up loudly with the manual commands.

## Test Plan
- [x] \`--skip-install\` copy → \`bun install\` (prepare formats + regenerates) → \`bun run check\` exit 0
- [x] Malformed-marker, missing-file, and retry-cap tests (5 new)
- [x] Full suite green on the branch