### PR TITLE
fix(scripts): setup:project UX — EOF guard, concurrency lock, help, friendly re-run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ README.original.md
 # PENDING_FORMAT_MARKER in lib/scripts/utils.ts; deleted by prepare.ts on the
 # next `bun install`, but ignore it in case that never runs.
 .setup-project-pending-format.json
+
+# setup:project concurrency lock (P-B3) — removed on exit, but ignore it in
+# case a crash left it behind.
+.setup-project.lock

--- a/lib/scripts/generate-shared.ts
+++ b/lib/scripts/generate-shared.ts
@@ -42,18 +42,119 @@ export function toCamelCase(str: string): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Exit gracefully when a @clack/prompts value is cancelled.
+ * Exit loudly when a @clack/prompts value is cancelled (P-D2).
  *
- * Calls `p.cancel(message)` and `process.exit(0)` when `p.isCancel(value)` is
- * true.  Returns the unwrapped value otherwise (the TypeScript overload ensures
- * the caller receives the plain type, not `symbol | T`).
+ * Calls `p.cancel(message)` (the pretty interactive box), writes a plain
+ * one-line version of `message` to stderr (so scripted/CI callers get a
+ * machine-visible reason even when they discard the styled stdout box), and
+ * exits 1 — not 0: a cancelled run never completed, so it should never look
+ * like success to a caller checking the exit code. `nonInteractiveHint`,
+ * when given, is appended to the stderr line (e.g. `--preset <key>` or
+ * `--keep <id,id,...>`) so a script that hit this by piping `</dev/null` or
+ * running under a non-interactive harness knows how to avoid the prompt
+ * next time.
+ *
+ * Returns the unwrapped value when not cancelled (the TypeScript overload
+ * ensures the caller receives the plain type, not `symbol | T`).
  */
-export function cancelGuard<T>(value: T | symbol, message: string): T {
+export function cancelGuard<T>(
+  value: T | symbol,
+  message: string,
+  nonInteractiveHint?: string
+): T {
   if (p.isCancel(value)) {
     p.cancel(message)
-    process.exit(0)
+    console.error(
+      nonInteractiveHint
+        ? `${message} — use ${nonInteractiveHint} instead.`
+        : message
+    )
+    process.exit(1)
   }
   return value as T
+}
+
+// ---------------------------------------------------------------------------
+// EOF guard
+// ---------------------------------------------------------------------------
+
+/** Private sentinel distinguishing "stdin closed" from a legitimate prompt value. */
+const EOF_SENTINEL: unique symbol = Symbol('clack:stdin-eof')
+
+/**
+ * Await an interactive @clack/prompts call, but fail loudly instead of
+ * silently exiting 0 when stdin closes (EOF) before the prompt resolves
+ * (P-D2).
+ *
+ * @clack/core's prompt engine only ever settles its promise on Enter/submit
+ * or Ctrl+C/cancel — never on stdin EOF. A script piped `</dev/null` (or run
+ * under any harness that closes stdin before answering) hangs forever from
+ * the awaited Promise's perspective; `p.isCancel()` is never reached because
+ * the prompt never resolves at all. With nothing else keeping Node's event
+ * loop alive, the process then exits 0 on its own once the loop drains — a
+ * silent, successful-looking no-op that did nothing.
+ *
+ * Races the prompt against stdin's `close` event. If stdin closes first,
+ * this prints the same clear stderr message `cancelGuard` would and exits 1
+ * immediately, instead of letting the silent exit-0 happen. Otherwise
+ * behaves exactly like `cancelGuard(await promptFn(), message, nonInteractiveHint)`.
+ *
+ * Answer-wins ordering: a legitimate final answer can race stdin's `close`
+ * event — e.g. `printf '\n' | bun run script` (a valid default-confirm
+ * keystroke immediately followed by the pipe closing) can fire `close`
+ * before @clack/core's own promise-resolution microtask for that keystroke
+ * has run, since `close` is a synchronous EventEmitter callback while a
+ * promise resolution's reactions are always at least one microtask removed.
+ * The `close` handler doesn't resolve the EOF race directly — it defers via
+ * `setImmediate`, which runs only after every already-queued microtask
+ * (including the prompt's own resolution below) has drained, so a real
+ * answer always gets to flip `answered` first. Only a genuinely-unanswered
+ * prompt — nothing pending to drain — reaches the EOF branch.
+ */
+export async function guardedPrompt<T>(
+  promptFn: () => Promise<T | symbol>,
+  message: string,
+  nonInteractiveHint?: string
+): Promise<T> {
+  let answered = false
+  let onClose: (() => void) | undefined
+
+  const detach = (): void => {
+    if (onClose) {
+      process.stdin.off('close', onClose)
+      onClose = undefined
+    }
+  }
+
+  const eof = new Promise<typeof EOF_SENTINEL>((resolve) => {
+    onClose = () => {
+      setImmediate(() => {
+        if (!answered) resolve(EOF_SENTINEL)
+      })
+    }
+    process.stdin.once('close', onClose)
+  })
+
+  const answer = promptFn().then((value) => {
+    answered = true
+    detach()
+    return value
+  })
+
+  try {
+    const result = await Promise.race([answer, eof])
+    if (result === EOF_SENTINEL) {
+      console.error(
+        `${message} (stdin closed before it could be answered)${
+          nonInteractiveHint ? ` — use ${nonInteractiveHint} instead.` : '.'
+        }`
+      )
+      process.exit(1)
+    }
+    return cancelGuard(result, message, nonInteractiveHint)
+  } finally {
+    detach()
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/scripts/setup-project.test.ts
+++ b/lib/scripts/setup-project.test.ts
@@ -16,6 +16,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 
 import { applyOpsToText, RequiredOpMatchError } from './ast-transforms'
+import { guardedPrompt } from './generate-shared'
 import {
   getIntegrationEntries,
   getIntegrationNames,
@@ -31,6 +32,7 @@ import {
   replaceAnchoredText,
   resolveTransitiveKeepSet,
   SELF_PRUNE_KEEP_TEST_FILES,
+  SETUP_PROJECT_PRUNED_STUB,
   shouldDisableCacheComponents,
   shouldSkipConfirm,
 } from './setup-project'
@@ -1430,6 +1432,7 @@ describe("P-C3 regression: kept bundle deps survive selfPrune's package.json wri
       ) as {
         dependencies?: Record<string, string>
         devDependencies?: Record<string, string>
+        scripts?: Record<string, string>
       }
 
       for (const dep of [
@@ -1449,10 +1452,340 @@ describe("P-C3 regression: kept bundle deps survive selfPrune's package.json wri
           `missing devDependency "${devDep}"`
         ).toBeTruthy()
       }
+
+      // P-B4: self-prune replaces (not deletes) the setup:project entry
+      // with a friendly, non-zero-exit stub — Bun's generic "Script not
+      // found" is gone, and the script file itself is really deleted.
+      expect(pkg.scripts?.['setup:project']).toBe(SETUP_PROJECT_PRUNED_STUB)
+      expect(
+        await pathExists(join(tmpRoot, 'lib/scripts/setup-project.ts'))
+      ).toBe(false)
     } finally {
       await rm(tmpRoot, { recursive: true, force: true })
     }
   }, 60000)
+})
+
+// ---------------------------------------------------------------------------
+// P-D2 — cancel/EOF guard: stdin closing before a prompt resolves must exit
+// 1 with a readable message, never fall through to a silent exit 0.
+//
+// Runs against the real repo tree directly (no rsync copy needed): with no
+// flags, guardedPrompt's stdin-close race fires before guardProjectRoot()'s
+// checks would matter and before any mutation, so this is read-only.
+// ---------------------------------------------------------------------------
+
+describe('P-D2: stdin EOF guard (guardedPrompt)', () => {
+  it('bun run setup:project </dev/null exits 1 with a readable stderr message', async () => {
+    const proc = Bun.spawnSync(['bun', 'lib/scripts/setup-project.ts'], {
+      cwd: projectRoot,
+      stdin: new Response(''), // closed stdin — simulates `</dev/null`
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    expect(proc.exitCode).toBe(1)
+    const stderr = proc.stderr.toString()
+    expect(stderr).toContain('Setup cancelled')
+    expect(stderr).toContain('stdin closed')
+    expect(stderr).toContain('--preset')
+  }, 20000)
+})
+
+// ---------------------------------------------------------------------------
+// P-D2 (LOW, cross-model review follow-up) — answer-wins ordering:
+// guardedPrompt must not false-cancel when a legitimate final answer races
+// stdin's `close` event (reproduced: a valid default confirm answer
+// immediately followed by pipe closure, e.g. `printf '\n' | script`).
+// ---------------------------------------------------------------------------
+
+describe('guardedPrompt (answer-wins ordering)', () => {
+  it('a prompt that resolves synchronously (before stdin close) still wins — baseline sanity check', async () => {
+    const promptFn = () =>
+      new Promise<string>((resolve) => {
+        // Both the answer and the close are already-settled by the time
+        // Promise.race examines them here, so this alone doesn't exercise
+        // the actual race (Promise.race's array-order tie-break already
+        // favors index 0 in that case) — see the next test for the real
+        // regression repro.
+        resolve('yes')
+        process.stdin.emit('close')
+      })
+
+    const result = await guardedPrompt(promptFn, 'test cancelled')
+    expect(result).toBe('yes')
+  })
+
+  it('a prompt that resolves one microtask AFTER stdin close still wins (the actual repro: setImmediate defers long enough for the answer to land first)', async () => {
+    const promptFn = () =>
+      new Promise<string>((resolve) => {
+        // This is the real regression repro: stdin closes first (its `eof`
+        // promise is already-settled by the time Promise.race runs), and
+        // the prompt's answer settles one microtask later — exactly what a
+        // real @clack/core resolution racing a piped stream's `close` can
+        // look like. Without the setImmediate defer, Promise.race picks
+        // the already-settled `eof` and this incorrectly exits as
+        // cancelled (verified against the pre-fix implementation).
+        process.stdin.emit('close')
+        queueMicrotask(() => resolve('no'))
+      })
+
+    const result = await guardedPrompt(promptFn, 'test cancelled')
+    expect(result).toBe('no')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// P-B6 — --help/-h was computed by parseCliFlags but never checked by
+// main(), so it silently fell through into a live interactive run instead
+// of printing usage.
+// ---------------------------------------------------------------------------
+
+describe('P-B6: --help prints usage and exits 0', () => {
+  it('lists every flag and every preset key, and exits 0', async () => {
+    const proc = Bun.spawnSync(
+      ['bun', 'lib/scripts/setup-project.ts', '--help'],
+      {
+        cwd: projectRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      }
+    )
+
+    expect(proc.exitCode).toBe(0)
+    const stdout = proc.stdout.toString()
+    expect(stdout).toContain('Usage:')
+    expect(stdout).toContain('--preset')
+    expect(stdout).toContain('--keep')
+    expect(stdout).toContain('--yes')
+    expect(stdout).toContain('--skip-install')
+    for (const key of Object.keys(PROJECT_PRESETS)) {
+      expect(stdout).toContain(key)
+    }
+  }, 20000)
+
+  it('-h is equivalent to --help', async () => {
+    const proc = Bun.spawnSync(['bun', 'lib/scripts/setup-project.ts', '-h'], {
+      cwd: projectRoot,
+      stdout: 'pipe',
+    })
+    expect(proc.exitCode).toBe(0)
+    expect(proc.stdout.toString()).toContain('Usage:')
+  }, 20000)
+})
+
+// ---------------------------------------------------------------------------
+// P-B3 — a concurrency lock: two setup:project runs racing in one workspace
+// used to interleave into a silent, contradictory hybrid (both exit 0).
+// ---------------------------------------------------------------------------
+
+describe('P-B3: concurrent setup:project runs', () => {
+  it('one run succeeds, the other fails immediately naming the lock', async () => {
+    const tmpRoot = await mkdtemp(join(tmpdir(), 'satus-lock-'))
+    try {
+      const rsync = Bun.spawnSync([
+        'rsync',
+        '-a',
+        '--exclude',
+        'node_modules',
+        '--exclude',
+        '.next',
+        '--exclude',
+        '.git',
+        `${projectRoot}/`,
+        `${tmpRoot}/`,
+      ])
+      expect(rsync.exitCode).toBe(0)
+
+      const spawnRun = () =>
+        Bun.spawn(
+          [
+            'bun',
+            'run',
+            'setup:project',
+            '--preset',
+            'blank',
+            '--yes',
+            '--skip-install',
+          ],
+          { cwd: tmpRoot, stdout: 'pipe', stderr: 'pipe' }
+        )
+
+      const procA = spawnRun()
+      const procB = spawnRun()
+      const [exitA, exitB] = await Promise.all([procA.exited, procB.exited])
+      const [outA, outB, errA, errB] = await Promise.all([
+        new Response(procA.stdout).text(),
+        new Response(procB.stdout).text(),
+        new Response(procA.stderr).text(),
+        new Response(procB.stderr).text(),
+      ])
+
+      const exits = [exitA, exitB]
+      // clack's p.log.error writes to stdout, not stderr — check both so
+      // this doesn't depend on which stream the CLI library picks.
+      const combinedOutputs = [outA + errA, outB + errB]
+
+      // Exactly one succeeds, exactly one fails.
+      expect(exits.filter((code) => code === 0)).toHaveLength(1)
+      expect(exits.filter((code) => code !== 0)).toHaveLength(1)
+
+      // The failing run's message names the lock and gives a recovery step.
+      const failingOutput =
+        combinedOutputs[exits.findIndex((code) => code !== 0)] ?? ''
+      expect(failingOutput).toContain(
+        'setup:project run appears to be in progress'
+      )
+      expect(failingOutput).toContain('.setup-project.lock')
+      expect(failingOutput.toLowerCase()).toContain('delete the lock')
+
+      // The lock is cleaned up once both runs have finished.
+      expect(await pathExists(join(tmpRoot, '.setup-project.lock'))).toBe(false)
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true })
+    }
+  }, 60000)
+})
+
+// ---------------------------------------------------------------------------
+// P-B3 follow-up (cross-model review MEDIUM finding): the lock used to leak
+// on SIGINT/SIGTERM — Bun doesn't reliably emit 'exit' for those signals, so
+// a `kill -TERM` mid-run (or Ctrl+C outside an active prompt) could leave
+// the lock directory behind forever, blocking every future run. Fixed with
+// explicit SIGINT/SIGTERM handlers (release + exit non-zero) plus a PID-file
+// stale-lock backstop for whatever still gets past those (e.g. SIGKILL).
+// ---------------------------------------------------------------------------
+
+describe('P-B3 follow-up: lock survives SIGTERM / stale-lock detection', () => {
+  const rsyncCopy = async (tmpRoot: string): Promise<void> => {
+    const rsync = Bun.spawnSync([
+      'rsync',
+      '-a',
+      '--exclude',
+      'node_modules',
+      '--exclude',
+      '.next',
+      '--exclude',
+      '.git',
+      `${projectRoot}/`,
+      `${tmpRoot}/`,
+    ])
+    expect(rsync.exitCode).toBe(0)
+  }
+
+  it('kill -TERM on a mid-run process releases the lock instead of leaking it', async () => {
+    const tmpRoot = await mkdtemp(join(tmpdir(), 'satus-sigterm-'))
+    try {
+      await rsyncCopy(tmpRoot)
+
+      // No flags → fully interactive → hangs at the first prompt once
+      // guardProjectRoot()/acquireLock() have already run, giving us a
+      // window where the lock exists and the process is still alive to
+      // signal. stdin stays open (not `</dev/null`) so this is a genuine
+      // "process running, mid-prompt" state, not the P-D2 EOF path.
+      const child = Bun.spawn(['bun', 'lib/scripts/setup-project.ts'], {
+        cwd: tmpRoot,
+        stdin: 'pipe',
+        stdout: 'ignore',
+        stderr: 'ignore',
+      })
+
+      const lockPath = join(tmpRoot, '.setup-project.lock')
+      const deadline = Date.now() + 10000
+      while (!(await pathExists(lockPath)) && Date.now() < deadline) {
+        await Bun.sleep(50)
+      }
+      expect(await pathExists(lockPath)).toBe(true)
+
+      child.kill('SIGTERM')
+      await child.exited
+
+      expect(await pathExists(lockPath)).toBe(false)
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true })
+    }
+  }, 30000)
+
+  it('a lock left by a dead PID is treated as stale — removed, and the run proceeds', async () => {
+    const tmpRoot = await mkdtemp(join(tmpdir(), 'satus-stale-'))
+    try {
+      await rsyncCopy(tmpRoot)
+
+      // A PID guaranteed to be dead: spawn a trivial process and wait for
+      // it to exit, then reuse its (now-dead) pid.
+      const dead = Bun.spawn(['bun', '-e', 'process.exit(0)'])
+      await dead.exited
+      const deadPid = dead.pid
+
+      const lockPath = join(tmpRoot, '.setup-project.lock')
+      await Bun.$`mkdir -p ${lockPath}`.quiet()
+      await Bun.write(join(lockPath, 'pid'), `${deadPid}\n`)
+
+      const proc = Bun.spawnSync(
+        [
+          'bun',
+          'run',
+          'setup:project',
+          '--preset',
+          'blank',
+          '--yes',
+          '--skip-install',
+        ],
+        { cwd: tmpRoot, stdout: 'pipe', stderr: 'pipe' }
+      )
+
+      const output = proc.stdout.toString() + proc.stderr.toString()
+      if (proc.exitCode !== 0) console.error(output)
+
+      expect(proc.exitCode).toBe(0)
+      expect(output.toLowerCase()).toContain('stale')
+      expect(output).toContain(String(deadPid))
+      // The run replaced the stale lock with its own (and released it on
+      // completion) rather than treating it as a genuine collision.
+      expect(await pathExists(lockPath)).toBe(false)
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true })
+    }
+  }, 30000)
+
+  it('a lock left by a LIVE PID is NOT treated as stale — still a genuine collision', async () => {
+    const tmpRoot = await mkdtemp(join(tmpdir(), 'satus-live-'))
+    try {
+      await rsyncCopy(tmpRoot)
+
+      // Our own test-runner process is unambiguously alive for the
+      // duration of this test.
+      const livePid = process.pid
+
+      const lockPath = join(tmpRoot, '.setup-project.lock')
+      await Bun.$`mkdir -p ${lockPath}`.quiet()
+      await Bun.write(join(lockPath, 'pid'), `${livePid}\n`)
+
+      const proc = Bun.spawnSync(
+        [
+          'bun',
+          'run',
+          'setup:project',
+          '--preset',
+          'blank',
+          '--yes',
+          '--skip-install',
+        ],
+        { cwd: tmpRoot, stdout: 'pipe', stderr: 'pipe' }
+      )
+
+      const output = proc.stdout.toString() + proc.stderr.toString()
+      expect(proc.exitCode).not.toBe(0)
+      expect(output).toContain('setup:project run appears to be in progress')
+      // The still-alive owner's lock is left exactly as it was.
+      expect(await pathExists(lockPath)).toBe(true)
+      expect(await Bun.file(join(lockPath, 'pid')).text()).toContain(
+        String(livePid)
+      )
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true })
+    }
+  }, 30000)
 })
 
 // ---------------------------------------------------------------------------

--- a/lib/scripts/setup-project.ts
+++ b/lib/scripts/setup-project.ts
@@ -29,6 +29,7 @@
  * Cross-platform compatible (Windows, macOS, Linux)
  */
 
+import { rmSync } from 'node:fs'
 import { cp, mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -43,7 +44,7 @@ import {
 } from './ast-transforms/index'
 import { removeBarrelLines } from './barrel-file'
 import { installBundle, stripAbsentIntegrationWiring } from './bundle-installer'
-import { cancelGuard } from './generate-shared'
+import { guardedPrompt } from './generate-shared'
 import {
   type CodeTransform,
   getBundle,
@@ -998,6 +999,17 @@ export const collectSelfPruneTestFiles = async (): Promise<string[]> => {
     .sort()
 }
 
+/**
+ * Replacement value for package.json's `setup:project` script entry once
+ * self-prune has deleted `lib/scripts/setup-project.ts` (P-B4). Previously
+ * the entry was deleted too, so `bun run setup:project` on an already-set-up
+ * project produced Bun's generic, unhelpful "Script not found" — this
+ * explains what happened and where to find the deleted script instead, and
+ * still exits non-zero (running it again was a mistake either way).
+ */
+export const SETUP_PROJECT_PRUNED_STUB =
+  "echo 'This project is already set up — setup:project deletes itself after its first run. Run `git log -- lib/scripts/setup-project.ts` (or check out an earlier commit) to find it again.' && exit 1"
+
 const selfPrune = async (
   pkg: PackageJson,
   dryRun: boolean
@@ -1018,23 +1030,29 @@ const selfPrune = async (
     }
   }
 
-  // Mutate the in-memory package.json scripts (no file write here)
+  // Mutate the in-memory package.json scripts (no file write here).
+  // test:setup's own test file is deleted above (self-prune's glob), so
+  // there's nothing coherent left for it to run — remove the entry
+  // outright, same as before. setup:project's script FILE is also deleted
+  // (below), but its package.json entry is REPLACED, not removed (P-B4) —
+  // see SETUP_PROJECT_PRUNED_STUB's docstring.
   const scriptsRemoved: string[] = []
   const scripts = pkg.scripts
   if (scripts) {
-    const scriptKeys = ['setup:project', 'test:setup']
-    for (const key of scriptKeys) {
-      if (key in scripts) {
-        scriptsRemoved.push(key)
-        if (!dryRun) {
-          delete scripts[key]
-        }
-      }
+    if ('test:setup' in scripts) {
+      scriptsRemoved.push('test:setup')
+      if (!dryRun) delete scripts['test:setup']
+    }
+    if ('setup:project' in scripts) {
+      scriptsRemoved.push('setup:project')
+      if (!dryRun) scripts['setup:project'] = SETUP_PROJECT_PRUNED_STUB
     }
   }
 
   if (dryRun && scriptsRemoved.length > 0) {
-    p.log.message(`  Would remove scripts: ${scriptsRemoved.join(', ')}`)
+    p.log.message(
+      `  Would remove test:setup and replace setup:project with a friendly stub`
+    )
   }
 
   s.stop(
@@ -1416,16 +1434,15 @@ const promptForIntegrations = async (): Promise<RemovableId[]> => {
   ]
 
   // Ask what kind of project to start
-  const selectedPreset = await p.select({
-    message: 'What kind of project are you building?',
-    options: presetOptions,
-  })
-
-  // Handle cancellation
-  if (p.isCancel(selectedPreset)) {
-    p.cancel('Setup cancelled')
-    process.exit(0)
-  }
+  const selectedPreset = await guardedPrompt(
+    () =>
+      p.select({
+        message: 'What kind of project are you building?',
+        options: presetOptions,
+      }),
+    'Setup cancelled',
+    '--preset <key> or --keep <id,id,...>'
+  )
 
   if (selectedPreset === 'custom') {
     // Build options for multiselect
@@ -1437,14 +1454,17 @@ const promptForIntegrations = async (): Promise<RemovableId[]> => {
     }))
 
     // Ask which integrations to keep
-    const customIntegrations = await p.multiselect({
-      message:
-        'Which integrations do you want to KEEP? (space to select, enter to confirm)',
-      options: integrationOptions,
-      required: false,
-    })
-
-    return cancelGuard(customIntegrations, 'Setup cancelled')
+    return guardedPrompt(
+      () =>
+        p.multiselect({
+          message:
+            'Which integrations do you want to KEEP? (space to select, enter to confirm)',
+          options: integrationOptions,
+          required: false,
+        }),
+      'Setup cancelled',
+      '--preset <key> or --keep <id,id,...>'
+    )
   }
 
   // Use preset integrations
@@ -1458,6 +1478,118 @@ const promptForIntegrations = async (): Promise<RemovableId[]> => {
   )
 
   return keepIntegrations
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency guard (P-B3)
+// ---------------------------------------------------------------------------
+
+/** Lock directory guarding against two concurrent setup:project runs. */
+const LOCK_PATH = resolvePath('.setup-project.lock')
+/** PID file inside the lock dir — the backstop for stale-lock detection. */
+const LOCK_PID_FILE = `${LOCK_PATH}/pid`
+
+/**
+ * True when a process with this PID is currently running. Uses the
+ * `kill(pid, 0)` idiom: signal 0 sends nothing, it only probes whether the
+ * process exists and is signalable. ESRCH means no such process (dead);
+ * EPERM means it exists but is owned by someone else (still alive).
+ */
+const isProcessAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+/**
+ * Release the lock directory. Synchronous by design — called from
+ * `process.on('exit', …)` and from the explicit SIGINT/SIGTERM handlers
+ * below, neither of which can await async cleanup.
+ */
+const releaseLockSync = (): void => {
+  try {
+    rmSync(LOCK_PATH, { recursive: true, force: true })
+  } catch {
+    // Best-effort — a failed cleanup here shouldn't mask the real exit.
+  }
+}
+
+/**
+ * Prevent two concurrent `setup:project` runs in one workspace from
+ * interleaving their mutations into a silent, contradictory hybrid (both
+ * exit 0, but package.json / integration files reflect neither run
+ * cleanly). `mkdir` (non-recursive) is atomic on POSIX filesystems: a
+ * second run's `mkdir` fails with EEXIST the instant the first run's lock
+ * directory exists, so there's no check-then-create race window a plain
+ * "does this file exist" check would have.
+ *
+ * Stale-lock detection: the lock directory carries a `pid` file naming the
+ * process that created it. When `mkdir` hits EEXIST, that PID is checked —
+ * if it's no longer running (a crash, a `kill -9`, or any termination path
+ * that outran even the signal handlers below), the lock is treated as
+ * stale: removed and re-acquired instead of blocking the run forever. A
+ * lock whose owning process IS still alive is genuinely in progress and
+ * still throws.
+ *
+ * Release paths: a synchronous `process.on('exit', …)` handler (registered
+ * immediately after acquiring the lock) covers normal completion,
+ * `guardedPrompt`/`cancelGuard`'s direct `process.exit()` calls on
+ * cancel/EOF, and thrown errors. That alone isn't sufficient — Bun doesn't
+ * reliably emit 'exit' for SIGINT/SIGTERM, so a Ctrl+C or `kill -TERM`
+ * outside an active prompt (where @clack/prompts' own keypress handler
+ * would otherwise catch it) can tear the process down before 'exit' fires.
+ * Explicit SIGINT/SIGTERM handlers below release the lock and exit
+ * non-zero directly, so the common case doesn't have to fall back to
+ * stale-PID detection at all — that's the backstop for whatever still gets
+ * past both (e.g. SIGKILL, which no userspace handler can intercept).
+ */
+const acquireLock = async (): Promise<void> => {
+  try {
+    await mkdir(LOCK_PATH)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+      throw error
+    }
+
+    let stalePid: number | undefined
+    try {
+      const pidText = await Bun.file(LOCK_PID_FILE).text()
+      const parsed = Number.parseInt(pidText.trim(), 10)
+      if (Number.isFinite(parsed)) stalePid = parsed
+    } catch {
+      // No readable pid file — can't prove the owning process is gone, so
+      // fall through to the "still in progress" error below rather than
+      // guessing.
+    }
+
+    if (stalePid === undefined || isProcessAlive(stalePid)) {
+      throw new Error(
+        `Another setup:project run appears to be in progress (lock: ${LOCK_PATH}).\n` +
+          "If that's not actually the case — e.g. a previous run crashed without cleaning up — delete the lock and retry:\n" +
+          `  rm -rf "${LOCK_PATH}"`
+      )
+    }
+
+    p.log.warn(
+      `Removing a stale setup:project lock left behind by pid ${stalePid} (no longer running): ${LOCK_PATH}`
+    )
+    await rm(LOCK_PATH, { recursive: true, force: true })
+    await mkdir(LOCK_PATH)
+  }
+
+  await Bun.write(LOCK_PID_FILE, `${process.pid}\n`)
+
+  process.on('exit', releaseLockSync)
+
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.on(signal, () => {
+      releaseLockSync()
+      process.exit(1)
+    })
+  }
 }
 
 /**
@@ -1484,13 +1616,61 @@ const guardProjectRoot = async (): Promise<void> => {
 }
 
 /**
+ * Print `--help`/`-h` usage (P-B6) and return — flags, every preset key
+ * (from `PROJECT_PRESETS`, so this can't drift out of sync with the actual
+ * preset list), and one example invocation.
+ */
+const printUsage = (): void => {
+  const presetLines = Object.entries(PROJECT_PRESETS)
+    .map(([key, preset]) => `    ${key.padEnd(10)} ${preset.description}`)
+    .join('\n')
+
+  console.log(`Satūs Project Setup
+
+Strip the template down to the integrations you're keeping, additively
+re-add them, and self-prune this setup machinery — see the file header of
+lib/scripts/setup-project.ts for the full step-by-step.
+
+Usage:
+  bun run setup:project [flags]
+
+Flags:
+  --preset <key>       Use a preset's integrations (skips the interactive prompt)
+  --keep <id,id,...>   Keep an explicit integration set ('' = lean core only)
+  --clean-homepage     Replace the manual landing page with a blank starter
+  --yes                Skip the final proceed/confirm prompt
+  --skip-install       Write package.json without running \`bun install\`
+  --dry-run, -d        Preview changes without writing anything
+  --help, -h           Show this help and exit
+
+Presets (--preset <key>):
+${presetLines}
+
+Example:
+  bun run setup:project --preset editorial --yes
+`)
+}
+
+/**
  * CLI entry point
  */
 const main = async (): Promise<void> => {
-  await guardProjectRoot()
-
   const argv = process.argv.slice(2)
-  const { dryRun } = parseCliFlags(argv)
+  const { dryRun, help } = parseCliFlags(argv)
+
+  // --help/-h (P-B6): parseCliFlags already computed this, but main() never
+  // checked it, so `--help` silently fell through into a live interactive
+  // setup:project run instead of showing usage. Checked before
+  // guardProjectRoot()/acquireLock() so it works regardless of cwd and never
+  // touches the lock file.
+  if (help) {
+    printUsage()
+    return
+  }
+
+  await guardProjectRoot()
+  await acquireLock()
+
   const presetFlag = getFlagValue(argv, '--preset')
   const keepFlag = getFlagValue(argv, '--keep')
   const yes = argv.includes('--yes')
@@ -1529,17 +1709,16 @@ const main = async (): Promise<void> => {
     keepIntegrations = await promptForIntegrations()
 
     // Offer to drop the manual landing page for a clean slate.
-    const cleanMarketingAnswer = await p.confirm({
-      message: 'Replace the manual landing page with a blank starter homepage?',
-      initialValue: false,
-    })
-
-    if (p.isCancel(cleanMarketingAnswer)) {
-      p.cancel('Setup cancelled')
-      process.exit(0)
-    }
-
-    cleanMarketing = cleanMarketingAnswer
+    cleanMarketing = await guardedPrompt(
+      () =>
+        p.confirm({
+          message:
+            'Replace the manual landing page with a blank starter homepage?',
+          initialValue: false,
+        }),
+      'Setup cancelled',
+      '--preset <key> or --keep <id,id,...>'
+    )
   }
 
   // Expand the kept set to include every transitive `requires` dependency
@@ -1596,11 +1775,19 @@ const main = async (): Promise<void> => {
   })
 
   if (!skipConfirm) {
-    const proceed = await p.confirm({
-      message: dryRun ? 'Preview changes?' : 'Proceed with setup?',
-    })
+    // guardedPrompt handles an explicit cancel (Ctrl+C) or stdin closing
+    // (EOF) — both exit 1 with a clear message. A deliberate "No" answer is
+    // a different, intentional outcome: exit 0, no error.
+    const proceed = await guardedPrompt(
+      () =>
+        p.confirm({
+          message: dryRun ? 'Preview changes?' : 'Proceed with setup?',
+        }),
+      'Setup cancelled',
+      '--yes (with --preset/--keep)'
+    )
 
-    if (p.isCancel(proceed) || !proceed) {
+    if (!proceed) {
       p.cancel('Setup cancelled')
       process.exit(0)
     }


### PR DESCRIPTION
## What this does
The ergonomics set from the process audit:

- **P-D2 (High, shared root cause)**: every \`@clack/prompts\` script exited 0 as a silent no-op when stdin closed before a prompt resolved — a false-positive success for any agent or CI driving them headlessly. The shared guard now prints what was cancelled (naming the non-interactive flags where they exist) and exits 1. From review: the answer-vs-EOF race resolves answer-wins via \`setImmediate\` ordering, so finite piped input can't false-cancel.
- **P-B3 (Med)**: two concurrent setup runs interleaved into a silent hybrid; now an atomic pid-carrying lock — second run fails immediately, SIGINT/SIGTERM release it, and a dead-PID stale lock is detected and cleared.
- **P-B4 (Low)**: post-self-prune re-runs get a friendly "already set up, see git history" stub instead of Bun's generic Script not found.
- **P-B6 (Low)**: \`--help\` prints usage with the real preset list instead of launching prompts.

## Test Plan
- [x] \`setup:project </dev/null\` → exit 1 with readable stderr
- [x] \`kill -TERM\` mid-run → lock released; stale-PID lock cleared by next run; live-PID still blocks
- [x] \`--help\` → usage + presets, exit 0
- [x] Full suite: 452 pass