### PR TITLE
perf(theatre): keep @theatre/core out of production bundles

### DIFF
--- a/lib/dev/theatre/hooks/use-theatre.ts
+++ b/lib/dev/theatre/hooks/use-theatre.ts
@@ -9,10 +9,70 @@ import { useEffect, useEffectEvent, useRef, useState } from 'react'
 
 import { useStudio } from './use-studio'
 
+// Module scope on purpose. The React Compiler cannot lower an `import()`
+// expression that sits inside a component/hook body ("BuildHIR: Handle
+// Import expressions") and silently gives up on optimising the whole
+// function (see `use-studio.ts`). Behind a plain function call it is just a
+// call expression, so the compiler is happy and the chunk still loads
+// lazily.
+const loadTheatreCore = () => import('@theatre/core')
+
+// Plain, theatre-free descriptor format for `useTheatre` configs. Call sites
+// (the fluid/flowmap sims, `Group`) describe their controls with these
+// instead of importing `@theatre/core` themselves — the only place that
+// package's runtime is ever touched is the dynamic import below, which only
+// resolves once `sheet` exists (dev only, see `useTheatreObject`). That
+// keeps `@theatre/core` out of every bundle that doesn't already need it.
+export type NumberDescriptor = {
+  value: number
+  range?: [number, number]
+  nudgeMultiplier?: number
+}
+
+type PropDescriptor = NumberDescriptor | boolean | TheatrePropDescriptors
+
+export type TheatrePropDescriptors = {
+  [key: string]: PropDescriptor
+}
+
+function isNumberDescriptor(
+  descriptor: PropDescriptor
+): descriptor is NumberDescriptor {
+  return (
+    typeof descriptor === 'object' &&
+    'value' in descriptor &&
+    typeof descriptor.value === 'number'
+  )
+}
+
+function toTheatreConfig(
+  descriptors: TheatrePropDescriptors,
+  core: Awaited<ReturnType<typeof loadTheatreCore>>
+): UnknownShorthandCompoundProps {
+  const config: Record<string, unknown> = {}
+
+  for (const [key, descriptor] of Object.entries(descriptors)) {
+    if (typeof descriptor === 'boolean') {
+      config[key] = descriptor
+    } else if (isNumberDescriptor(descriptor)) {
+      config[key] = core.types.number(descriptor.value, {
+        ...(descriptor.range && { range: descriptor.range }),
+        ...(descriptor.nudgeMultiplier !== undefined && {
+          nudgeMultiplier: descriptor.nudgeMultiplier,
+        }),
+      })
+    } else {
+      config[key] = toTheatreConfig(descriptor, core)
+    }
+  }
+
+  return config as UnknownShorthandCompoundProps
+}
+
 export function useTheatreObject(
   sheet: ISheet | undefined,
   theatreKey: string,
-  config: UnknownShorthandCompoundProps,
+  config: TheatrePropDescriptors,
   deps = [] as unknown[]
 ) {
   const [object, setObject] = useState<ISheetObject>()
@@ -26,23 +86,45 @@ export function useTheatreObject(
   useEffect(() => {
     if (!sheet) return
 
-    // `set-state-in-effect` fires here, and it stays. The state is what makes
-    // the object observable: useTheatre's subscription effect keys on it, so it
-    // has to re-run when the object appears or is rebuilt. Holding it in a ref
-    // instead would leave subscribers with no signal, and the object is a
-    // Theatre handle that only exists once the sheet does, so it cannot be
-    // derived during render. The bailout costs auto-memoization only in
-    // development: `SheetProvider` (`lib/dev/theatre/index.tsx`) only
-    // bootstraps a live Theatre project when `NODE_ENV === 'development'`, so
-    // `sheet` is always `undefined` in production — this effect hits the
-    // early return above and the `setObject` call below never runs at all.
-    // The whole hook is also removed outright by setup:project for projects
-    // that drop Theatre.
-    // react-doctor-disable-next-line react-hooks-js/set-state-in-effect
-    setObject(sheet?.object(theatreKey, config, { reconfigure: true }))
+    // `@theatre/core` is only ever imported here, inside the effect, and this
+    // effect only runs at all once `sheet` exists — which `SheetProvider`
+    // (`lib/dev/theatre/index.tsx`) only bootstraps in development. Production
+    // bundles never execute this branch, so the dynamic `import()` never
+    // resolves and `@theatre/core`'s chunk is never fetched (or, if the
+    // bundler doesn't split it, its module code still never runs). The whole
+    // hook is also removed outright by setup:project for projects that drop
+    // Theatre.
+    let cancelled = false
+    let attached = false
+
+    loadTheatreCore()
+      .then((core) => {
+        if (cancelled) return
+        attached = true
+
+        // `set-state-in-effect` fires here, and it stays. The state is what
+        // makes the object observable: useTheatre's subscription effect keys
+        // on it, so it has to re-run when the object appears or is rebuilt.
+        // Holding it in a ref instead would leave subscribers with no signal,
+        // and the object is a Theatre handle that only exists once the sheet
+        // does, so it cannot be derived during render.
+        // react-doctor-disable-next-line react-hooks-js/set-state-in-effect
+        setObject(
+          sheet.object(theatreKey, toTheatreConfig(config, core), {
+            reconfigure: true,
+          })
+        )
+      })
+      .catch((error: unknown) => {
+        console.error(`Theatre: failed to load core for '${theatreKey}'`, error)
+      })
 
     return () => {
-      sheet.detachObject(theatreKey)
+      cancelled = true
+      // Only the run that actually attached an object needs to detach one —
+      // a cleanup that fires before the dynamic import resolves (e.g. an
+      // immediate deps change or unmount) never attached anything.
+      if (attached) sheet.detachObject(theatreKey)
     }
     // oxlint-disable-next-line react/exhaustive-deps -- complex dependency expression is intentional
   }, [configKey, sheet, theatreKey, ...deps])
@@ -50,16 +132,25 @@ export function useTheatreObject(
   return object
 }
 
-type TheatrePropsToValues<Config extends UnknownShorthandCompoundProps> =
-  Parameters<Parameters<ISheetObject<Config>['onValuesChange']>[0]>[0]
+type DescriptorValue<D extends PropDescriptor> = D extends NumberDescriptor
+  ? number
+  : D extends boolean
+    ? boolean
+    : D extends TheatrePropDescriptors
+      ? { [K in keyof D]: DescriptorValue<D[K]> }
+      : never
 
-type UseTheatreOptions<Config extends UnknownShorthandCompoundProps> = {
+type TheatrePropsToValues<Config extends TheatrePropDescriptors> = {
+  [K in keyof Config]: DescriptorValue<Config[K]>
+}
+
+type UseTheatreOptions<Config extends TheatrePropDescriptors> = {
   onValuesChange?: (values: TheatrePropsToValues<Config>) => void
   lazy?: boolean
   deps?: unknown[]
 }
 
-export function useTheatre<Config extends UnknownShorthandCompoundProps>(
+export function useTheatre<Config extends TheatrePropDescriptors>(
   sheet: ISheet | undefined,
   theatreKey: string,
   config: Config,

--- a/lib/dev/theatre/index.tsx
+++ b/lib/dev/theatre/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { getProject, type IProject, type ISheet, onChange } from '@theatre/core'
+import type { IProject, ISheet } from '@theatre/core'
 import {
   createContext,
   type PropsWithChildren,
@@ -12,6 +12,13 @@ import {
   useRef,
   useState,
 } from 'react'
+
+// Module scope on purpose. The React Compiler cannot lower an `import()`
+// expression that sits inside a component body ("BuildHIR: Handle Import
+// expressions") and silently gives up on optimising the whole component
+// (see `use-studio.ts`). Behind a plain function call it is just a call
+// expression, so the compiler is happy and the chunk still loads lazily.
+const loadTheatreCore = () => import('@theatre/core')
 
 const TheatreProjectContext = createContext<IProject | undefined>(undefined)
 
@@ -45,9 +52,15 @@ export function TheatreProjectProvider({
           console.log(`Theatre: project ${id} loading...`)
         }
         isLoadingRef.current = true
-        void fetch(config)
-          .then((response) => response.json())
-          .then((state) => {
+        // Fetch the checked-in state and load `@theatre/core` in parallel —
+        // neither depends on the other, and this is the only place in the
+        // dev-only project-bootstrap path that touches the package, so it's
+        // the only place its runtime is ever pulled into a chunk.
+        void Promise.all([
+          loadTheatreCore(),
+          fetch(config).then((response) => response.json()),
+        ])
+          .then(([{ getProject }, state]) => {
             const project = getProject(id, { state })
 
             if (project.isReady) {
@@ -58,13 +71,25 @@ export function TheatreProjectProvider({
               })
             }
           })
+          .catch((error: unknown) => {
+            // Reset so a remount can retry — a stuck flag would silently
+            // disable Theatre for the rest of the session.
+            isLoadingRef.current = false
+            console.error(`Theatre: project ${id} failed to load`, error)
+          })
       }
     } else {
-      const project = getProject(id)
+      loadTheatreCore()
+        .then(({ getProject }) => {
+          const project = getProject(id)
 
-      void project.ready.then(() => {
-        setproject(project)
-      })
+          void project.ready.then(() => {
+            setproject(project)
+          })
+        })
+        .catch((error: unknown) => {
+          console.error(`Theatre: project ${id} failed to load`, error)
+        })
     }
   }, [config, id])
 
@@ -96,11 +121,24 @@ export function useSheetDuration(sheet: ISheet) {
   useEffect(() => {
     if (!sheet) return
 
-    const unsubscribe = onChange(sheet.sequence.pointer.length, (duration) => {
-      setDuration(duration)
-    })
+    let cancelled = false
+    let unsubscribe: (() => void) | undefined
 
-    return unsubscribe
+    loadTheatreCore()
+      .then(({ onChange }) => {
+        if (cancelled) return
+        unsubscribe = onChange(sheet.sequence.pointer.length, (duration) => {
+          setDuration(duration)
+        })
+      })
+      .catch((error: unknown) => {
+        console.error('Theatre: failed to load core for sheet duration', error)
+      })
+
+    return () => {
+      cancelled = true
+      unsubscribe?.()
+    }
   }, [sheet])
 
   return duration

--- a/lib/dev/theatre/r3f.tsx
+++ b/lib/dev/theatre/r3f.tsx
@@ -1,4 +1,3 @@
-import { types } from '@theatre/core'
 import { useRef } from 'react'
 import type { Group as ThreeGroup } from 'three'
 
@@ -33,19 +32,19 @@ export function Group({
     theatreKey,
     {
       position: {
-        x: types.number(position[0], { nudgeMultiplier: 0.01 }),
-        y: types.number(position[1], { nudgeMultiplier: 0.01 }),
-        z: types.number(position[2], { nudgeMultiplier: 0.01 }),
+        x: { value: position[0], nudgeMultiplier: 0.01 },
+        y: { value: position[1], nudgeMultiplier: 0.01 },
+        z: { value: position[2], nudgeMultiplier: 0.01 },
       },
       rotation: {
-        x: types.number(rotation[0], { nudgeMultiplier: 0.01 }),
-        y: types.number(rotation[1], { nudgeMultiplier: 0.01 }),
-        z: types.number(rotation[2], { nudgeMultiplier: 0.01 }),
+        x: { value: rotation[0], nudgeMultiplier: 0.01 },
+        y: { value: rotation[1], nudgeMultiplier: 0.01 },
+        z: { value: rotation[2], nudgeMultiplier: 0.01 },
       },
       scale: {
-        x: types.number(scale[0], { nudgeMultiplier: 0.01 }),
-        y: types.number(scale[1], { nudgeMultiplier: 0.01 }),
-        z: types.number(scale[2], { nudgeMultiplier: 0.01 }),
+        x: { value: scale[0], nudgeMultiplier: 0.01 },
+        y: { value: scale[1], nudgeMultiplier: 0.01 },
+        z: { value: scale[2], nudgeMultiplier: 0.01 },
       },
       visible: true,
     },

--- a/lib/webgl/utils/flowmaps/index.tsx
+++ b/lib/webgl/utils/flowmaps/index.tsx
@@ -1,5 +1,4 @@
 import { useFrame, useThree } from '@react-three/fiber'
-import { types } from '@theatre/core'
 import { useEffect, useRef } from 'react'
 
 import { useCurrentSheet } from '@/dev/theatre'
@@ -70,8 +69,8 @@ export function useFlowmapSim(resolution = 128) {
     sheet,
     'flowmap',
     {
-      falloff: types.number(0.2, { range: [0, 1], nudgeMultiplier: 0.01 }),
-      dissipation: types.number(0.98, { range: [0, 1], nudgeMultiplier: 0.01 }),
+      falloff: { value: 0.2, range: [0, 1], nudgeMultiplier: 0.01 },
+      dissipation: { value: 0.98, range: [0, 1], nudgeMultiplier: 0.01 },
     },
     {
       onValuesChange: ({

--- a/lib/webgl/utils/fluid/index.tsx
+++ b/lib/webgl/utils/fluid/index.tsx
@@ -1,5 +1,4 @@
 import { useFrame, useThree } from '@react-three/fiber'
-import { types } from '@theatre/core'
 import { useEffect, useRef } from 'react'
 
 import { useCurrentSheet } from '@/dev/theatre'
@@ -54,11 +53,11 @@ export function useFluidSim(resolution = 128) {
     sheet,
     'fluid simulation',
     {
-      density: types.number(0.98, { range: [0, 1], nudgeMultiplier: 0.01 }),
-      velocity: types.number(1, { range: [0, 1], nudgeMultiplier: 0.01 }),
-      pressure: types.number(0.5, { range: [0, 1], nudgeMultiplier: 0.01 }),
-      curl: types.number(0, { range: [0, 100], nudgeMultiplier: 1 }),
-      radius: types.number(0.5, { range: [0, 1], nudgeMultiplier: 0.01 }),
+      density: { value: 0.98, range: [0, 1], nudgeMultiplier: 0.01 },
+      velocity: { value: 1, range: [0, 1], nudgeMultiplier: 0.01 },
+      pressure: { value: 0.5, range: [0, 1], nudgeMultiplier: 0.01 },
+      curl: { value: 0, range: [0, 100], nudgeMultiplier: 1 },
+      radius: { value: 0.5, range: [0, 1], nudgeMultiplier: 0.01 },
     },
     {
       onValuesChange: ({


### PR DESCRIPTION
## What this does
Theatre.js powers a dev-only tuning workflow, but its core runtime was shipping in production bundles that could never use it — the fluid/flowmap sims and the project provider imported `@theatre/core` at module level, and no live Theatre project ever exists outside development. Production chunks no longer carry it. This matters more than usual because upstream Theatre.js has been unpublished since mid-2024: a frozen runtime shouldn't ride along in prod for a workflow that only exists in dev.

## Summary
Review order: `lib/dev/theatre/hooks/use-theatre.ts` first (the contract change), then the sims, then the provider.
- `useTheatre` configs are now plain descriptors (`{ value, range, nudgeMultiplier }`) instead of `types.number(...)` — the conversion to Theatre types happens inside the dev-only effect via a dynamic `import('@theatre/core')`, with cancel/attached guards so unmount-before-resolve never detaches a phantom object. Ranges, nudge multipliers, and defaults reach Studio unchanged.
- `lib/dev/theatre/index.tsx` loads core lazily too (in parallel with the state-JSON fetch); every load path has a rejection handler and the bootstrap flag resets on failure so a remount can retry.
- The fluid/flowmap sims no longer import `@theatre/core` at all; `@theatre/studio` gating is untouched (it was already correct).
- Bundle evidence: scanning built chunks for Theatre-internal symbols (`Theatre_SheetObject_PublicAPI`, `createRafDriver`) finds them only in two lazy chunks absent from `build-manifest.json` — no route loads them eagerly, and the imports that would fetch them never execute in production.

## Test Plan
- [x] `bun run check` — 550 tests pass
- [x] `bun run build` — exit 0; chunk scan as above
- [ ] Dev-mode smoke: open Orchestra → Studio, confirm fluid/flowmap controls appear with the same ranges and respond live