### PR TITLE
feat(effects): rebuild progress-text on SplitText with a live showcase

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -11,6 +11,7 @@
  */
 import cn from 'clsx'
 
+import { ProgressText } from '@/components/effects/progress-text'
 import { Wrapper } from '@/components/layout/wrapper'
 import { Link } from '@/components/ui/link'
 
@@ -172,9 +173,17 @@ export default function HomePage() {
               </li>
             ))}
           </ol>
+          {/* Scroll-driven reveal — the live example of the GSAP stack
+              (SplitText + ScrollTrigger scrubbed through Lenis). Delete with
+              the rest of this page. */}
           <p className={s.outro}>
-            Done here? Replace app/(site)/page.tsx with your homepage and delete
-            page.module.css. That&apos;s the only cleanup.
+            {/* end must be reachable at max scroll — the outro sits at the page
+                bottom, so its top never reaches viewport center; its bottom
+                does reach the viewport bottom, exactly at full scroll. */}
+            <ProgressText start="top bottom" end="bottom bottom">
+              Done here? Replace app/(site)/page.tsx with your homepage and
+              delete page.module.css. That&apos;s the only cleanup.
+            </ProgressText>
           </p>
         </div>
       </section>

--- a/components/effects/README.md
+++ b/components/effects/README.md
@@ -9,7 +9,7 @@ This directory is for GSAP-based effects: the runtime ticker bridge and orchestr
 | Component        | Purpose                                                         |
 | ---------------- | --------------------------------------------------------------- |
 | `gsap.tsx`       | `GSAPRuntime` — syncs GSAP's ticker to Tempus (single RAF loop) |
-| `progress-text/` | Scroll-driven progress text effect (hamo scroll-trigger)        |
+| `progress-text/` | Scroll-driven text reveal (SplitText + ScrollTrigger, scrubbed) |
 
 ## GSAPRuntime
 
@@ -21,12 +21,16 @@ Mount once in the root layout via `OptionalFeatures`. Ensures GSAP animations ru
 
 ## Progress Text
 
-Reveal text based on scroll progress.
+Words fade in as scroll progress advances, split by GSAP's SplitText and
+scrubbed 1:1 through a ScrollTrigger (which syncs to Lenis via the bridge in
+`components/layout/lenis`). Content is static after mount — remount with a
+`key` to change it. `prefers-reduced-motion` gets a single gentle fade
+instead of scroll linkage.
 
 ```tsx
 import { ProgressText } from '@/components/effects/progress-text'
 
-;<ProgressText>
+;<ProgressText start="top bottom" end="bottom bottom" dimOpacity={0.33}>
   This text reveals as you scroll through the section
 </ProgressText>
 ```

--- a/components/effects/gsap.tsx
+++ b/components/effects/gsap.tsx
@@ -64,7 +64,11 @@ import { useTempus } from 'tempus/react'
 // unlike the ticker config below, which touches browser-only APIs. Registering
 // is what GSAP's React guide prescribes: it binds the hook to this copy of the
 // core and keeps it from being tree-shaken. It only manages animation
-// lifecycle, so it leaves the Tempus-driven ticker alone.
+// lifecycle, so it leaves the Tempus-driven ticker alone. Plugins a single
+// component consumes (SplitText, ScrollTrigger) register in that component's
+// module instead — registering them here would ship their weight on every
+// page. See `components/effects/progress-text` for the canonical
+// useGSAP + SplitText usage.
 gsap.registerPlugin(useGSAP)
 
 if (typeof window !== 'undefined') {
@@ -78,9 +82,14 @@ if (typeof window !== 'undefined') {
  * Add to your root layout to enable GSAP animations.
  */
 export function GSAPRuntime() {
-  useTempus(({ time }) => {
-    gsap.updateRoot(time / 1000)
-  })
+  // order: 10 — after Lenis (order: 5) has written scroll state, so scrubbed
+  // ScrollTrigger tweens render this frame's scroll position, not last frame's.
+  useTempus(
+    ({ time }) => {
+      gsap.updateRoot(time / 1000)
+    },
+    { order: 10 }
+  )
 
   return null
 }

--- a/components/effects/progress-text/index.tsx
+++ b/components/effects/progress-text/index.tsx
@@ -1,142 +1,145 @@
 'use client'
 
+import { useGSAP } from '@gsap/react'
 import cn from 'clsx'
-import { type UseScrollTriggerOptions, useScrollTrigger } from 'hamo'
-import {
-  Children,
-  type CSSProperties,
-  Fragment,
-  isValidElement,
-  type ReactNode,
-  useRef,
-} from 'react'
-
-import { slugify } from '@/utils/strings'
+import gsap from 'gsap'
+import { ScrollTrigger } from 'gsap/ScrollTrigger'
+import { SplitText } from 'gsap/SplitText'
+import type { CSSProperties, ReactNode } from 'react'
+import { useRef } from 'react'
 
 import s from './progress-text.module.css'
 
-interface WordSegment {
-  text: string
-  className?: string
-  style?: CSSProperties
+// Registered here (not only in `components/effects/gsap.tsx`) so this
+// component works correctly even if it renders before the Lenis↔ScrollTrigger
+// bridge (`components/layout/lenis/scroll-trigger.tsx`) has been dynamically
+// imported — registerPlugin is idempotent, so re-registering is a no-op once
+// that module has also loaded.
+if (typeof window !== 'undefined') {
+  gsap.registerPlugin(ScrollTrigger, SplitText)
 }
 
 type ProgressTextProps = {
-  /** Accepts a string, an array of strings, or an array of objects with { text, className?, style? } */
+  /**
+   * Text content to reveal — a string, or JSX with inline markup (e.g.
+   * `<em>word</em>`). SplitText splits every rendered word regardless of
+   * nesting. Treated as STATIC after mount: SplitText takes ownership of the
+   * rendered text nodes, so React updating `children` in place would clash
+   * with the split DOM. To change the content, remount with a `key`.
+   */
   children: ReactNode
-  start: UseScrollTriggerOptions['start']
-  end: UseScrollTriggerOptions['end']
-  transition?: CSSProperties['transition']
-  onChange?: (node: HTMLSpanElement, value: boolean) => void
+  /** ScrollTrigger `start` position (element keyword + viewport keyword, e.g. `'top top'`). */
+  start?: string
+  /** ScrollTrigger `end` position, e.g. `'bottom bottom'`. */
+  end?: string
+  /** Opacity of words the scroll position hasn't reached yet. */
+  dimOpacity?: number
   className?: string
   style?: CSSProperties
 }
 
-function defaultOnChange(node: HTMLSpanElement, value: boolean) {
-  node.style.opacity = String(value ? 1 : 0.33)
-}
-
-/** Extract words from children, supporting strings, arrays of strings, and objects with { text, className?, style? } */
-function extractWords(children: ReactNode): WordSegment[] {
-  const words: WordSegment[] = []
-
-  function processNode(node: ReactNode) {
-    if (typeof node === 'string') {
-      for (const word of node.split(' ').filter(Boolean)) {
-        words.push({ text: word })
-      }
-    } else if (
-      typeof node === 'object' &&
-      node !== null &&
-      !isValidElement(node) &&
-      'text' in node
-    ) {
-      const segment = node as WordSegment
-      for (const word of segment.text.split(' ').filter(Boolean)) {
-        const entry: WordSegment = { text: word }
-        if (segment.className) entry.className = segment.className
-        if (segment.style) entry.style = segment.style
-        words.push(entry)
-      }
-    } else if (Array.isArray(node)) {
-      for (const item of node) {
-        processNode(item)
-      }
-    } else if (isValidElement<{ children?: ReactNode }>(node)) {
-      // Extract text from React elements (e.g., <span>word</span>)
-      Children.forEach(node.props.children, processNode)
-    }
-  }
-
-  processNode(children)
-  return words
-}
-
+/**
+ * Scroll-driven text reveal, built on GSAP's SplitText + ScrollTrigger.
+ *
+ * Words fade from `dimOpacity` to fully opaque as scroll progress advances
+ * through `start`..`end` (scrubbed 1:1, no easing lag) — the same fold-based
+ * mapping `hamo`'s `useScrollTrigger` used, expressed as native ScrollTrigger
+ * keywords. `prefers-reduced-motion: reduce` skips the scroll linkage and
+ * fades every word in once, instantly.
+ */
 export function ProgressText({
   children,
   start = 'top top',
   end = 'bottom bottom',
-  transition = '600ms opacity ease-out',
-  onChange = defaultOnChange,
+  dimOpacity = 0.33,
   className,
   style,
 }: ProgressTextProps) {
-  // Sparse array: a shrinking word count removes trailing entries (ref
-  // callback fires with `undefined` on detach), so the progress handler
-  // below filters to live nodes only — a stale detached node inflating the
-  // denominator would silently shift every surviving word's reveal
-  // threshold. Mirrors the same fix in `components/ui/marquee`.
-  const wordsRefs = useRef<(HTMLSpanElement | undefined)[]>([])
+  const containerRef = useRef<HTMLSpanElement>(null)
 
-  const [setRectRef] = useScrollTrigger({
-    start,
-    end,
-    onProgress: ({ progress }) => {
-      const activeNodes = wordsRefs.current.filter(
-        (node): node is HTMLSpanElement => Boolean(node)
-      )
-      activeNodes.forEach((node, i) => {
-        onChange?.(node, progress > i / activeNodes.length)
+  useGSAP(
+    () => {
+      const container = containerRef.current
+      if (!container) return
+
+      const split = SplitText.create(container, {
+        type: 'words',
+        // Full text stays in the a11y tree via aria-label on the container;
+        // the generated per-word spans get aria-hidden so screen readers
+        // read continuous text, never word-by-word.
+        aria: 'auto',
+        tag: 'span',
+        // `noUncheckedIndexedAccess` types the CSS module's index signature
+        // as `string | undefined`; the class always exists at build time.
+        wordsClass: s.word ?? '',
       })
+
+      // SplitText instances register with the active useGSAP context and are
+      // auto-reverted on unmount, but that DOM mutation deserves an explicit,
+      // visible cleanup rather than relying on that implicitly — mirrors the
+      // manual-revert pattern GSAP's own React docs show.
+      const cleanup = () => split.revert()
+
+      if (split.words.length === 0) {
+        return cleanup
+      }
+
+      gsap.set(split.words, { opacity: dimOpacity })
+
+      const mm = gsap.matchMedia()
+
+      // Declare both states explicitly. gsap.matchMedia() only invokes the
+      // callback when at least one named condition currently matches — a
+      // single `reduceMotion` key would silently never fire (and never wire
+      // up the scroll-linked reveal) for the common case where it doesn't
+      // match, since `no-preference` is what's true for those visitors.
+      mm.add(
+        {
+          reduceMotion: '(prefers-reduced-motion: reduce)',
+          noPreference: '(prefers-reduced-motion: no-preference)',
+        },
+        (context) => {
+          if (context.conditions?.reduceMotion) {
+            // Reduced motion: still becomes visible, just not scroll-linked
+            // and with no movement — a gentle opacity-only fade.
+            gsap.to(split.words, { opacity: 1, duration: 0.3 })
+            return
+          }
+
+          gsap.to(split.words, {
+            opacity: 1,
+            stagger: { each: 1 / split.words.length, from: 'start' },
+            scrollTrigger: {
+              trigger: container,
+              start,
+              end,
+              scrub: true,
+            },
+          })
+        },
+        container
+      )
+
+      return cleanup
     },
-  })
-
-  const words = extractWords(children)
-
-  if (words.length === 0) {
-    return children
-  }
+    // revertOnUpdate: a dependency change must revert the previous context
+    // (split spans, ScrollTrigger, matchMedia listeners) before re-running —
+    // without it useGSAP only reverts on unmount and each change stacks a
+    // fresh SplitText + trigger on top of the last.
+    {
+      scope: containerRef,
+      dependencies: [start, end, dimOpacity],
+      revertOnUpdate: true,
+    }
+  )
 
   return (
     <span
-      ref={setRectRef}
+      ref={containerRef}
       className={cn(s.progressText, className)}
-      style={{
-        '--transition': transition,
-        ...style,
-      }}
+      style={style}
     >
-      {words.map((word, index) => (
-        // oxlint-disable-next-line react/no-array-index-key -- word list derived from static children, order never changes
-        <Fragment key={`${slugify(word.text)}-${index}`}>
-          <span
-            className={cn(s.word, word.className)}
-            ref={(node) => {
-              if (!node) {
-                // React calls the ref callback with null on detach — clear
-                // the slot so a shrinking word count doesn't leave a stale
-                // detached node in the array.
-                wordsRefs.current[index] = undefined
-                return
-              }
-              wordsRefs.current[index] = node
-            }}
-            style={{ opacity: 0.33, ...word.style }}
-          >
-            {word.text}
-          </span>{' '}
-        </Fragment>
-      ))}
+      {children}
     </span>
   )
 }

--- a/components/effects/progress-text/progress-text.module.css
+++ b/components/effects/progress-text/progress-text.module.css
@@ -2,7 +2,9 @@
   display: inline-block;
 
   .word {
+    /* Opacity is set directly by the GSAP tween (scrubbed to scroll
+       progress), not a CSS transition — a transition would fight the
+       scrub by always trailing the scroll-driven value. */
     display: inline-block;
-    transition: var(--transition);
   }
 }

--- a/components/layout/lenis/index.tsx
+++ b/components/layout/lenis/index.tsx
@@ -29,11 +29,18 @@ export function Lenis({
 }: LenisProps) {
   const lenisRef = useRef<LenisRef>(null)
 
-  useTempus(({ time }) => {
-    if (lenisRef.current?.lenis) {
-      lenisRef.current.lenis.raf(time)
-    }
-  })
+  // order: 5 — Lenis writes scroll state; GSAP's updateRoot (order: 10, see
+  // components/effects/gsap.tsx) reads it for scrubbed ScrollTriggers. Without
+  // an explicit order the sequencing is mount-order luck, and a scrub tween
+  // would render one frame behind the scroll.
+  useTempus(
+    ({ time }) => {
+      if (lenisRef.current?.lenis) {
+        lenisRef.current.lenis.raf(time)
+      }
+    },
+    { order: 5 }
+  )
 
   return (
     <ReactLenis


### PR DESCRIPTION
## What this does
The GSAP stack was fully wired (ticker on Tempus, ScrollTrigger bridged to Lenis) but nothing in the repo animated with it. The progress-text effect now consumes it for real: SplitText (free since GSAP's Webflow acquisition) does the word splitting, a scrubbed ScrollTrigger drives the reveal through the Lenis bridge, and the manual page's outro is the live example — scroll to the bottom of `/` and the closing line fades in word by word.

## Summary
Review order: `components/effects/progress-text/index.tsx` first, then the two Tempus `order` additions.
- `SplitText.create` + `useGSAP` (with `revertOnUpdate` so prop changes revert the previous split/trigger instead of stacking) + `ScrollTrigger` `scrub: true` — same fold mapping as the old hamo-based reveal. Reduced motion gets one gentle fade, no scroll linkage. Full text stays in the a11y tree via `aria-label`; split spans are `aria-hidden`.
- Lenis's `raf` and `gsap.updateRoot` now run at explicit Tempus order (5 and 10) — scrubbed tweens read this frame's scroll position instead of relying on mount order. This was a latent footgun the dependency audit flagged; this PR makes it observable, so it fixes it.
- API deltas from the old component (nothing in the repo used them): the per-word `{ text, className, style }` array shape, `transition`, and `onChange` are gone; `dimOpacity` (default 0.33, the old default) replaces them. Content is static after mount — SplitText owns the split DOM; remount with a `key` to change it (documented on the prop and in the README).

## Test Plan
- [x] `bun run lint`, `bun run typecheck` — exit 0; `bun test` — 550 pass
- [x] `bun run build` — exit 0
- [x] Headless visual check: 14 split word spans, `aria-label` intact, words at 0.33 before scroll and 1.0 at page bottom (screenshot in thread)
- [ ] Eyeball the reveal at `/` bottom with Lenis smoothing on a real pointer