### PR TITLE
chore: pin bun 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run `bun dev` and open [localhost:3000](http://localhost:3000) — the landing p
 
 ## Quick Start
 
-Requires Node.js >= 24.20 and Bun >= 1.3.5.
+Requires Node.js >= 24.20 and Bun >= 1.4.0.
 
 ```bash
 bun install

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   "engines": {
     "node": ">=24.20.0"
   },
-  "packageManager": "bun@1.3.5",
+  "packageManager": "bun@1.4.0",
   "trustedDependencies": [
     "oxlint",
     "oxfmt",


### PR DESCRIPTION
## What this does

CI now runs the same Bun version as local development. The `packageManager` field pinned 1.3.5, and every `setup-bun` step reads that field, so CI had been on 1.3.5 while machines had moved to 1.4.0.

## Summary

- `package.json` `packageManager` → `bun@1.4.0` (1.4.0 is the latest release; no 1.4.1 yet).
- README requirement line updated to match.
- `bun install --frozen-lockfile` under 1.4.0: no lockfile changes.

## Test plan

- [ ] CI `ci` and `e2e` jobs green under 1.4.0 (the setup-bun steps log the resolved version).
- [ ] Locally: `bun run check` on 1.4.0, expect 676 pass / 0 fail.