### PR TITLE
perf: gate WebGL on hardware rendering and window load, skip late reveals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ export function MyComponent({
 - Combine with `cn()` from `clsx`
 - Use `h-dvh` not `h-screen`
 - Animate only `transform`, `opacity` (compositor properties)
+- A below-fold CSS `background-image` downloads at page load on any rendered element, even at `opacity: 0` or inside a collapsed section; only `display: none` on the element itself, or a missing rule, prevents the fetch. Gate the class that carries the `url()` behind an IntersectionObserver (`rootMargin: '100% 0px'` starts the fetch one viewport early), or use `<img loading="lazy">`. Measured on shield.fi (2026-08-28): three hidden stills, 302 KB, cost 5.4 s of Slow 3G load before anyone scrolled.
 
 ### Animation
 
@@ -112,6 +113,7 @@ export function MyComponent({
 - **Micro-interactions** (hover, toggle, ≤200ms) → CSS transitions.
 - **Smooth scroll** → Lenis; **RAF scheduling** → Tempus.
 - Honor reduced-motion: the global neutralizer in `global.css` zeroes CSS animation; JS/WebGL gates via `usePreferredReducedMotion`.
+- **Deferrable heavy boot** (WebGL contexts, shader compiles, third-party runtimes) → `useAfterLoad` / `<AfterLoad>` (`lib/hooks/use-after-load.ts`). Work done during hydration is billed as blocking time for pixels the DOM is already painting. The root `<Canvas>` already waits for `window.load`; `force` opts out.
 
 ### Design tokens and custom utilities
 
@@ -141,6 +143,12 @@ Exception: use `useRef` for class/object instantiation to prevent infinite loops
 ### WebGL cleanup
 
 Dispose materials, textures, geometries, and render targets on unmount. Remove event listeners. Gate debug UI with `process.env.NODE_ENV === 'development'`.
+
+`isWebGL` from `useDeviceDetection` is false on software renderers (SwiftShader, llvmpipe), not just on devices without WebGL2. PageSpeed Insights and other cloud Lighthouse runners have no GPU; a shader that runs there pegs the main thread for the whole audit and the report comes back as "page stopped responding". Anything that mounts a WebGL surface must go through that gate or the DOM fallback never gets exercised where it matters.
+
+### Fonts
+
+`next/font` preloads every family it loads. Preloads compete with the render-blocking stylesheet on a slow link, so a family used only below the fold should pass `preload: false` (measured on shield.fi, 2026-08-28: dropping one below-fold preload moved Slow 3G first paint from 3.8 s to 3.0 s). For licensed self-hosted fonts, subset to the characters the site renders: a preloaded base file (Basic Latin plus the punctuation in use) and an `-Ext` file (rest of Latin-1, General Punctuation) declared with a `unicode-range` so it downloads only when one of those characters renders.
 
 ### Git
 

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -59,6 +59,7 @@ Quick-reference for every component, hook, and utility in the Satus starter kit.
 
 | Hook | Import | Signature |
 |------|--------|-----------|
+| useAfterLoad | `@/hooks/use-after-load` | `() => boolean` |
 | useDeviceDetection | `@/hooks/use-device-detection` | `()` |
 | usePrefetch | `@/hooks/use-prefetch` | `(href: Route | null | undefined, options?: IntersectionObserverInit)` |
 | useReveal | `@/hooks/use-reveal` | `({ threshold = 0, rootMargin = '0px 0px -25% 0px', once = true, }: UseRevealOptions = {})` |

--- a/components/layout/wrapper/index.tsx
+++ b/components/layout/wrapper/index.tsx
@@ -18,6 +18,8 @@ import { Theme } from '@/components/layout/theme'
 import type { ThemeName } from '@/styles/config'
 import { Canvas } from '@/webgl/components/canvas'
 
+import s from './wrapper.module.css'
+
 function isLenisOptions(value: boolean | LenisOptions): value is LenisOptions {
   return typeof value === 'object'
 }
@@ -57,7 +59,7 @@ interface WrapperProps extends React.HTMLAttributes<HTMLDivElement> {
  * @param props.lenis - Whether to enable smooth scrolling with Lenis
  * @param props.webgl - Whether to mount the WebGL canvas for this page
  * @param props.children - Page content
- * @param props.className - Additional CSS classes
+ * @param props.className - Additional CSS classes for the main element. Tailwind utilities and CSS Module classes passed here override the base layout (see wrapper.module.css).
  *
  * @example
  * ```tsx
@@ -111,11 +113,7 @@ export function Wrapper({
       {/* Header is rendered here - do NOT add another in layout.tsx */}
       <Header />
       <Canvas root={webgl}>
-        <main
-          id="main-content"
-          className={cn('relative flex grow flex-col', className)}
-          {...props}
-        >
+        <main id="main-content" className={cn(s.main, className)} {...props}>
           {children}
         </main>
       </Canvas>

--- a/components/layout/wrapper/wrapper.module.css
+++ b/components/layout/wrapper/wrapper.module.css
@@ -1,0 +1,15 @@
+/**
+ * Base layout for the main element. Declared in `@layer utilities` with
+ * zero specificity (`:where`) so a Tailwind utility passed through
+ * `className` (same layer, real specificity) overrides it, and a consumer
+ * CSS Module rule (unlayered) overrides both. Kept out of the `cn()` call so
+ * an override never depends on stylesheet order between two utilities.
+ */
+@layer utilities {
+  :where(.main) {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+  }
+}

--- a/lib/hooks/README.md
+++ b/lib/hooks/README.md
@@ -9,15 +9,16 @@ import { useMediaQuery } from 'hamo'
 
 ## Available Hooks
 
-| Hook                        | Purpose                                                                                                |
-| --------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `useReveal`                 | Reveal-on-scroll via IntersectionObserver — CSS-driven, compositor-thread; reduced-motion + no-JS safe |
-| `useDeviceDetection`        | Detect screen size, input, motion preference, WebGL support                                            |
-| `usePrefetch`               | Prefetch routes on visibility                                                                          |
-| `useOnlineStatus`           | Network online/offline status                                                                          |
-| `usePreferredColorScheme`   | System theme preference                                                                                |
-| `usePreferredReducedMotion` | Reduced motion preference                                                                              |
-| `useDocumentVisibility`     | Tab visibility state                                                                                   |
+| Hook                         | Purpose                                                                                                |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `useReveal`                  | Reveal-on-scroll via IntersectionObserver — CSS-driven, compositor-thread; reduced-motion + no-JS safe |
+| `useDeviceDetection`         | Detect screen size, input, motion preference, WebGL support (hardware only)                            |
+| `useAfterLoad` / `AfterLoad` | True once `window.load` fired — mount gate for deferrable heavy boot (WebGL, third-party runtimes)     |
+| `usePrefetch`                | Prefetch routes on visibility                                                                          |
+| `useOnlineStatus`            | Network online/offline status                                                                          |
+| `usePreferredColorScheme`    | System theme preference                                                                                |
+| `usePreferredReducedMotion`  | Reduced motion preference                                                                              |
+| `useDocumentVisibility`      | Tab visibility state                                                                                   |
 
 ## useReveal
 
@@ -38,6 +39,34 @@ function Cards({ items }) {
     </div>
   )
 }
+```
+
+## useAfterLoad
+
+True once the window has fully loaded. Use it as the mount gate for work that
+is heavy and invisible during hydration: a WebGL context boot, a shader
+compile, a third-party runtime. The root `<Canvas>` already uses it, so
+WebGL content portaled into the root canvas needs nothing extra.
+
+```tsx
+import { useAfterLoad } from '@/hooks/use-after-load'
+
+function Ground() {
+  const afterLoad = useAfterLoad()
+  return afterLoad ? <ShaderGround /> : <div className={s.still} />
+}
+```
+
+`<AfterLoad>` is the same gate as a component, for server trees that cannot
+call the hook. Children pass through as references, so nothing new enters the
+client bundle:
+
+```tsx
+import { AfterLoad } from '@/hooks/use-after-load'
+
+;<AfterLoad>
+  <SanityLive />
+</AfterLoad>
 ```
 
 ## Browser API Hooks
@@ -176,6 +205,8 @@ Types: `Rect`, `Transform`, `TransformRef`, `UseScrollTriggerOptions`.
 
 Detect device capabilities (SSR-safe): screen size, input method, motion
 preference, WebGL support, Safari, and inline-video autoplay support.
+`isWebGL` is false on software renderers (SwiftShader, llvmpipe, headless
+audit runners), so the DOM fallback is what PageSpeed Insights measures.
 
 ```tsx
 import { useDeviceDetection } from '@/hooks/use-device-detection'

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -4,6 +4,7 @@
  */
 
 export { useMediaQuery } from 'hamo'
+export { AfterLoad, useAfterLoad } from './use-after-load'
 export { useDeviceDetection } from './use-device-detection'
 export { usePrefetch } from './use-prefetch'
 export { useReveal } from './use-reveal'

--- a/lib/hooks/use-after-load.ts
+++ b/lib/hooks/use-after-load.ts
@@ -1,0 +1,66 @@
+'use client'
+
+import { type ReactNode, useSyncExternalStore } from 'react'
+
+/**
+ * True once the window has fully loaded: the mount gate for deferrable heavy
+ * work. Booting a WebGL context and compiling its programs during hydration
+ * bills main-thread time to the load for pixels the DOM is already painting
+ * (measured on shield.fi mobile, 2026-08-12: 1,170 ms of Lighthouse total
+ * blocking time, 190 ms after gating; performance score 71 to 93; LCP
+ * unchanged). Nothing visible changes when the work is deferred, the effect
+ * simply starts a beat after load.
+ *
+ * Reads `document.readyState` through `useSyncExternalStore`, so a component
+ * mounting after load sees `true` on its first render (no extra commit) and
+ * the server snapshot is `false` (nothing deferred ever renders in SSR HTML).
+ *
+ * @example
+ * ```tsx
+ * const afterLoad = useAfterLoad()
+ * return afterLoad ? <HeavyThing /> : null
+ * ```
+ */
+export function useAfterLoad(): boolean {
+  return useSyncExternalStore(subscribeToLoad, getIsLoaded, getServerIsLoaded)
+}
+
+/**
+ * The hook as a children gate, for server trees: a server component cannot
+ * call the hook, and importing the gated module into a client wrapper drags
+ * that module's whole graph into the client bundle. Children created by the
+ * server pass through as references instead, so nothing new enters the
+ * client graph and lazy internals fire only when the gate finally renders
+ * them.
+ *
+ * @example
+ * ```tsx
+ * <AfterLoad>
+ *   <SanityLive />
+ * </AfterLoad>
+ * ```
+ */
+export function AfterLoad({ children }: { children: ReactNode }) {
+  return useAfterLoad() ? children : null
+}
+
+const NOOP_UNSUBSCRIBE = () => {
+  // Nothing subscribed, nothing to tear down.
+}
+
+function subscribeToLoad(onChange: () => void) {
+  if (document.readyState === 'complete') {
+    // Already loaded: nothing will ever notify, and the snapshot is stable.
+    return NOOP_UNSUBSCRIBE
+  }
+  window.addEventListener('load', onChange, { once: true })
+  return () => window.removeEventListener('load', onChange)
+}
+
+function getIsLoaded() {
+  return document.readyState === 'complete'
+}
+
+function getServerIsLoaded() {
+  return false
+}

--- a/lib/hooks/use-device-detection.ts
+++ b/lib/hooks/use-device-detection.ts
@@ -42,10 +42,44 @@ function detectIsSafari() {
   return cache.isSafari
 }
 
+/**
+ * Renderer strings that mean WebGL is being emulated on the CPU: Chrome's
+ * SwiftShader (headless Chrome, cloud audit runners such as PageSpeed
+ * Insights, VMs without a GPU), Mesa's llvmpipe/softpipe (Linux without
+ * drivers), and generic "Software" adapters. A context still comes back, so
+ * a bare `getContext('webgl2')` check passes, but every frame is main-thread
+ * work: measured on shield.fi with `--use-angle=swiftshader` (2026-08-28),
+ * Lighthouse recorded 28 s of blocking time on desktop and 149 s on mobile,
+ * and PageSpeed Insights gave up with "the page stopped responding". Those
+ * machines get the DOM fallback instead, same as no-WebGL2 devices.
+ */
+const SOFTWARE_RENDERER = /swiftshader|llvmpipe|softpipe|software/i
+
+function probeSupportsWebGL(): boolean {
+  const probe = document.createElement('canvas').getContext('webgl2')
+  if (!probe) return false
+
+  try {
+    // Chrome 101+ returns the unmasked renderer from RENDERER directly; older
+    // browsers and Firefox need the debug extension for the real string.
+    const debug = probe.getExtension('WEBGL_debug_renderer_info')
+    const renderer = String(
+      debug
+        ? probe.getParameter(debug.UNMASKED_RENDERER_WEBGL)
+        : probe.getParameter(probe.RENDERER)
+    )
+    return !SOFTWARE_RENDERER.test(renderer)
+  } finally {
+    // Chrome caps live WebGL contexts at ~16 per page and evicts the oldest
+    // when a new one is created. A probe context that is never released holds
+    // one of those slots for the rest of the session, and once the cap is hit
+    // the real canvas can be the one evicted. Release it explicitly.
+    probe.getExtension('WEBGL_lose_context')?.loseContext()
+  }
+}
+
 function detectSupportsWebGL() {
-  cache.supportsWebGL ??= !!document
-    .createElement('canvas')
-    .getContext('webgl2')
+  cache.supportsWebGL ??= probeSupportsWebGL()
   return cache.supportsWebGL
 }
 
@@ -71,7 +105,8 @@ function getStaticDetectionServerSnapshot() {
 
 /**
  * Detect device capabilities: screen size, input method, motion preference,
- * WebGL support, Safari, and inline-video autoplay support.
+ * WebGL support (hardware-accelerated only, see `SOFTWARE_RENDERER`), Safari,
+ * and inline-video autoplay support.
  *
  * @example
  * ```tsx

--- a/lib/hooks/use-reveal.ts
+++ b/lib/hooks/use-reveal.ts
@@ -19,8 +19,9 @@ import { useEffect, useLayoutEffect, useRef } from 'react'
  *
  * Degrades gracefully: with JS disabled the `data-reveal` attribute is never
  * set, so the CSS hidden state (scoped under `[data-reveal]`) never applies and
- * content renders visible. Under `prefers-reduced-motion` the element is
- * revealed immediately and the observer is skipped.
+ * content renders visible. Under `prefers-reduced-motion`, or when the bundle
+ * hydrated late enough that the visitor was already reading the SSR text, the
+ * element is revealed immediately and the observer is skipped.
  *
  * The reveal CSS contract lives once, globally, in `lib/styles/css/global.css`;
  * per-section knobs are set on the container in its own CSS module:
@@ -52,6 +53,24 @@ const useIsomorphicLayoutEffect =
   // oxlint-disable-next-line anti-slop/no-runtime-typeof -- SSR guard; literal typeof enables bundler dead-code elimination
   typeof window === 'undefined' ? useEffect : useLayoutEffect
 
+/**
+ * Entrance animations are for content the visitor has not seen yet. On a slow
+ * connection the server-rendered text paints and is readable long before the
+ * bundle arrives; hydrating then hides it and replays the entrance, yanking
+ * copy the visitor is mid-sentence in, and stamps LCP at hydration time
+ * (measured on shield.fi, throttled mobile, 2026-08-28: 7.0 s LCP for a
+ * paragraph that first painted at 1.2 s). When the bundle itself landed this
+ * late, skip the choreography and reveal instantly.
+ *
+ * Module scope on purpose: this captures how late the FIRST load's bundle
+ * was, once. Client-side navigations mount fresh DOM that has never painted,
+ * so their entrances stay correct regardless of this flag, and on a session
+ * that started slow, skipping later entrances too errs on the side of the
+ * struggling device.
+ */
+// oxlint-disable-next-line anti-slop/no-runtime-typeof -- SSR guard; literal typeof enables bundler dead-code elimination
+const HYDRATED_LATE = typeof window !== 'undefined' && performance.now() > 2500
+
 interface UseRevealOptions {
   /** IntersectionObserver threshold (0–1). Default 0. */
   threshold?: number
@@ -82,8 +101,12 @@ export function useReveal<T extends HTMLElement = HTMLElement>({
       item.style.setProperty('--reveal-index', String(index))
     })
 
-    // Respect reduced motion: reveal immediately, never observe.
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    // Respect reduced motion, and never re-hide content the visitor could
+    // already read (see HYDRATED_LATE): reveal immediately, never observe.
+    if (
+      HYDRATED_LATE ||
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ) {
       element.dataset.reveal = 'visible'
       return
     }

--- a/lib/styles/fonts.ts
+++ b/lib/styles/fonts.ts
@@ -4,6 +4,10 @@ import { Oswald, Spline_Sans_Mono } from 'next/font/google'
 // Spline Sans Mono 300–700), so one file per family covers every weight the
 // styles use. Pinning explicit weights would download a separate static file
 // each and snap in-between weights (500, 600) to the nearest loaded one.
+// Both families are used above the fold, so the default preload is right.
+// A family used only below the fold should set `preload: false` (see
+// AGENTS.md § Fonts): its preload competes with the render-blocking
+// stylesheet on slow links.
 const display = Oswald({
   subsets: ['latin'],
   display: 'swap',

--- a/lib/webgl/components/canvas/index.tsx
+++ b/lib/webgl/components/canvas/index.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react'
 
 import Orchestra from '@/lib/dev/orchestra'
+import { useAfterLoad } from '@/lib/hooks/use-after-load'
 import { useDeviceDetection } from '@/lib/hooks/use-device-detection'
 import {
   claimPrimary,
@@ -127,6 +128,7 @@ export function Canvas({
 }: CanvasProps) {
   const { isWebGL, isReducedMotion } = useDeviceDetection()
   const webglDevToggleEnabled = useWebGLDevKillSwitch()
+  const afterLoad = useAfterLoad()
 
   // Only a root canvas mounts the WebGL surface; it uses the shared store
   // tunnels so content portals into it from anywhere. A non-root <Canvas> is a
@@ -134,8 +136,16 @@ export function Canvas({
   const WebGLTunnel = root ? getWebGLTunnel() : undefined
   const DOMTunnel = root ? getDOMTunnel() : undefined
 
-  // `force` is an explicit escape hatch — it bypasses both the WebGL
-  // capability check and the reduced-motion preference.
+  // `force` is an explicit escape hatch — it bypasses the WebGL capability
+  // check, the reduced-motion preference, and the after-load gate.
+  //
+  // The after-load gate (`useAfterLoad`) keeps the renderer boot and shader
+  // compile off the critical path: during hydration that work is billed as
+  // blocking time against pixels the DOM is already painting, so the canvas
+  // mounts once `window.load` fires instead. `force` skips it because a
+  // canvas that carries CONTENT (not decoration) may need to be up for first
+  // paint; the cost of that choice is the blocking time this gate exists to
+  // avoid, so `force` should come with a measurement.
   //
   // ⚠ Because reduced-motion (and non-WebGL devices) means the canvas may
   // never mount, anything that puts CONTENT in WebGL — not just decoration —
@@ -147,7 +157,9 @@ export function Canvas({
   // of that (including `force`) — useful for isolating perf work to the DOM
   // side of a page without physically deleting `<Canvas root>`.
   const shouldRender =
-    webglDevToggleEnabled && root && ((isWebGL && !isReducedMotion) || force)
+    webglDevToggleEnabled &&
+    root &&
+    ((isWebGL && !isReducedMotion && afterLoad) || force)
   const contextValue: CanvasContextValue =
     WebGLTunnel && DOMTunnel
       ? { active: true, WebGLTunnel, DOMTunnel }

--- a/next.config.ts
+++ b/next.config.ts
@@ -127,6 +127,14 @@ const nextConfig: NextConfig = {
     // instant-navigation cluster that is still opt-in (varyParams and
     // optimisticRouting are default-on).
     cachedNavigations: true,
+    // Not setting `inlineCss: true`. Measured 2026-09-02 (Lighthouse mobile,
+    // 3 runs each, localhost build): FCP 905 -> 810 ms, LCP 3.40 -> 3.40 s,
+    // TBT and CLS unchanged. It removed 4 stylesheets (14 KB transfer) but
+    // grew the document from 10 to 33 KB transfer (45 -> 176 KB raw), and
+    // that CSS also rides in every RSC payload. A 100 ms first-paint gain
+    // for +9 KB on the wire and no LCP movement is not worth it here; the
+    // starter's LCP is the throttled shell floor, not CSS delivery. A client
+    // project with more render-blocking CSS should re-measure.
     // Native Rust port of the React Compiler, run inside Turbopack. Pairs
     // with the top-level `reactCompiler: true`.
     turbopackRustReactCompiler: true,


### PR DESCRIPTION
## What this does

PageSpeed Insights and other GPU-less audit runners no longer hang on the WebGL canvas: software renderers now count as no-WebGL and get the DOM fallback. The root canvas also waits for the window load event before booting, so shader compiles stop counting as blocking time during hydration. On slow connections, text that was already readable is never hidden and re-animated by the reveal hook.

Ported from the shield-swap mobile performance work (docs/audits/performance-audit-2026-08-28.md in that repo).

## Summary

Review order: start with `lib/hooks/use-device-detection.ts`, then `lib/hooks/use-after-load.ts` and the canvas gate; the rest is docs.

- `use-device-detection.ts`: the WebGL2 probe reads the unmasked renderer string and rejects SwiftShader, llvmpipe, softpipe, and generic software adapters. The probe context is released with `loseContext()` so it no longer holds one of Chrome's ~16 context slots.
- `use-after-load.ts` (new): `useAfterLoad()` and `<AfterLoad>` via `useSyncExternalStore` on `document.readyState`. The root `<Canvas>` gate includes it; `force` bypasses it and the comment names the cost.
- `use-reveal.ts`: skips the entrance when the bundle hydrates more than 2.5 s into page life (module-scope flag, first load only).
- `components/layout/wrapper`: base layout moves into a layered `:where()` CSS module so a `className` utility overrides it deterministically instead of by stylesheet order.
- `next.config.ts`: `inlineCss` measured and rejected, numbers in the comment (FCP 905 to 810 ms, LCP flat at 3.40 s, document transfer 10 to 33 KB).
- AGENTS.md and hooks README: guidance for below-fold background images, font preloads, the after-load gate, and the stricter `isWebGL`.

## Test plan

- [ ] `bun run check` passes (682 tests, manifest up to date)
- [ ] `bun run build && bun next start`, open the homepage with the Network panel throttled to Slow 3G: the canvas element appears only after the load event
- [ ] Launch Chrome with `--use-angle=swiftshader`, open the homepage: no canvas mounts, no console errors
- [ ] Lighthouse mobile on the local build: performance score and CLS unchanged from main (92 / 0 in my runs)