### PR TITLE
style: layer component CSS modules so consumer className utilities win

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ export function MyComponent({
 - Tailwind (~80%): spacing, colors, typography
 - CSS Modules (~20%): complex animations, custom layouts, CSS specificity
 - Combine with `cn()` from `clsx`
+- A component that exposes `className` wraps its CSS module in `@layer components { ... }`. Tailwind v4 orders that layer below `utilities`, and unlayered CSS always beats layered CSS, so precedence becomes: consumer CSS module, then consumer Tailwind utility, then the component's own module. Without the layer an unlayered module rule beats every utility a consumer passes, whatever `cn()` outputs, and no class-merging library changes that. `image.module.css` layers into `utilities` on purpose so Tailwind `object-*` classes win by specificity; that is the one exception. This is why the starter does not carry `tailwind-merge`: the conflicts here are module versus utility, which layers decide, not utility versus utility.
 - Use `h-dvh` not `h-screen`
 - Animate only `transform`, `opacity` (compositor properties)
 - A below-fold CSS `background-image` downloads at page load on any rendered element, even at `opacity: 0` or inside a collapsed section; only `display: none` on the element itself, or a missing rule, prevents the fetch. Gate the class that carries the `url()` behind an IntersectionObserver (`rootMargin: '100% 0px'` starts the fetch one viewport early), or use `<img loading="lazy">`. Measured on shield.fi (2026-08-28): three hidden stills, 302 KB, cost 5.4 s of Slow 3G load before anyone scrolled.

--- a/components/effects/progress-text/progress-text.module.css
+++ b/components/effects/progress-text/progress-text.module.css
@@ -1,10 +1,12 @@
-.progressText {
-  display: inline-block;
-
-  .word {
-    /* Opacity is set directly by the GSAP tween (scrubbed to scroll
-       progress), not a CSS transition — a transition would fight the
-       scrub by always trailing the scroll-driven value. */
+@layer components {
+  .progressText {
     display: inline-block;
+
+    .word {
+      /* Opacity is set directly by the GSAP tween (scrubbed to scroll
+         progress), not a CSS transition — a transition would fight the
+         scrub by always trailing the scroll-driven value. */
+      display: inline-block;
+    }
   }
 }

--- a/components/layout/wrapper/wrapper.module.css
+++ b/components/layout/wrapper/wrapper.module.css
@@ -1,12 +1,5 @@
-/**
- * Base layout for the main element. Declared in `@layer utilities` with
- * zero specificity (`:where`) so a Tailwind utility passed through
- * `className` (same layer, real specificity) overrides it, and a consumer
- * CSS Module rule (unlayered) overrides both. Kept out of the `cn()` call so
- * an override never depends on stylesheet order between two utilities.
- */
-@layer utilities {
-  :where(.main) {
+@layer components {
+  .main {
     position: relative;
     display: flex;
     flex-direction: column;

--- a/components/ui/accordion/accordion.module.css
+++ b/components/ui/accordion/accordion.module.css
@@ -1,6 +1,8 @@
-.accordion {
-  .body {
-    overflow: hidden;
-    transition: height 600ms var(--ease-out-expo);
+@layer components {
+  .accordion {
+    .body {
+      overflow: hidden;
+      transition: height 600ms var(--ease-out-expo);
+    }
   }
 }

--- a/components/ui/alert-dialog/alert-dialog.module.css
+++ b/components/ui/alert-dialog/alert-dialog.module.css
@@ -1,131 +1,133 @@
-.backdrop {
-  position: fixed;
-  inset: 0;
-  background-color: oklch(0 0 0 / 0.5);
-  z-index: 100;
-  backdrop-filter: blur(2px);
+@layer components {
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background-color: oklch(0 0 0 / 0.5);
+    z-index: 100;
+    backdrop-filter: blur(2px);
 
-  /* Base UI animation states */
-  transition: opacity 150ms ease-out;
-  opacity: 1;
+    /* Base UI animation states */
+    transition: opacity 150ms ease-out;
+    opacity: 1;
 
-  &[data-starting-style],
-  &[data-ending-style] {
-    opacity: 0;
-  }
-}
-
-.popup {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 101;
-  background-color: var(--color-primary);
-  border: 1px solid var(--color-secondary);
-  border-radius: mobile-vw(8px);
-  padding: mobile-vw(24px);
-  max-width: min(400px, 90vw);
-  width: 100%;
-  box-shadow: 0 8px 32px oklch(0 0 0 / 0.2);
-
-  /* Base UI animation states */
-  transition:
-    transform 150ms ease-out,
-    opacity 150ms ease-out;
-  opacity: 1;
-
-  &[data-starting-style],
-  &[data-ending-style] {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(0.95);
-  }
-
-  @media (--desktop) {
-    border-radius: desktop-vw(8px);
-    padding: desktop-vw(24px);
-  }
-}
-
-.title {
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: var(--color-secondary);
-  margin: 0 0 mobile-vw(8px);
-
-  @media (--desktop) {
-    margin: 0 0 desktop-vw(8px);
-  }
-}
-
-.description {
-  color: var(--color-secondary);
-  opacity: 0.7;
-  margin: 0 0 mobile-vw(20px);
-  line-height: 1.5;
-
-  @media (--desktop) {
-    margin: 0 0 desktop-vw(20px);
-  }
-}
-
-.actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: mobile-vw(8px);
-
-  @media (--desktop) {
-    gap: desktop-vw(8px);
-  }
-}
-
-.cancel,
-.confirm {
-  padding: mobile-vw(8px) mobile-vw(16px);
-  border-radius: mobile-vw(4px);
-  font-size: inherit;
-  font-family: inherit;
-  cursor: pointer;
-  border: none;
-  transition:
-    background-color 150ms ease,
-    color 150ms ease;
-
-  @media (--desktop) {
-    padding: desktop-vw(8px) desktop-vw(16px);
-    border-radius: desktop-vw(4px);
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--color-contrast);
-    outline-offset: 2px;
-  }
-}
-
-.cancel {
-  background-color: transparent;
-  color: var(--color-secondary);
-  border: 1px solid var(--color-secondary);
-
-  @media (--hover) {
-    &:hover {
-      background-color: var(--color-secondary);
-      color: var(--color-primary);
-    }
-  }
-}
-
-.confirm {
-  background-color: var(--color-contrast);
-  color: var(--color-primary);
-
-  @media (--hover) {
-    &:hover {
-      opacity: 0.9;
+    &[data-starting-style],
+    &[data-ending-style] {
+      opacity: 0;
     }
   }
 
-  &.destructive {
-    background-color: oklch(0.577 0.2152 27.33);
+  .popup {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 101;
+    background-color: var(--color-primary);
+    border: 1px solid var(--color-secondary);
+    border-radius: mobile-vw(8px);
+    padding: mobile-vw(24px);
+    max-width: min(400px, 90vw);
+    width: 100%;
+    box-shadow: 0 8px 32px oklch(0 0 0 / 0.2);
+
+    /* Base UI animation states */
+    transition:
+      transform 150ms ease-out,
+      opacity 150ms ease-out;
+    opacity: 1;
+
+    &[data-starting-style],
+    &[data-ending-style] {
+      opacity: 0;
+      transform: translate(-50%, -50%) scale(0.95);
+    }
+
+    @media (--desktop) {
+      border-radius: desktop-vw(8px);
+      padding: desktop-vw(24px);
+    }
+  }
+
+  .title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--color-secondary);
+    margin: 0 0 mobile-vw(8px);
+
+    @media (--desktop) {
+      margin: 0 0 desktop-vw(8px);
+    }
+  }
+
+  .description {
+    color: var(--color-secondary);
+    opacity: 0.7;
+    margin: 0 0 mobile-vw(20px);
+    line-height: 1.5;
+
+    @media (--desktop) {
+      margin: 0 0 desktop-vw(20px);
+    }
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: mobile-vw(8px);
+
+    @media (--desktop) {
+      gap: desktop-vw(8px);
+    }
+  }
+
+  .cancel,
+  .confirm {
+    padding: mobile-vw(8px) mobile-vw(16px);
+    border-radius: mobile-vw(4px);
+    font-size: inherit;
+    font-family: inherit;
+    cursor: pointer;
+    border: none;
+    transition:
+      background-color 150ms ease,
+      color 150ms ease;
+
+    @media (--desktop) {
+      padding: desktop-vw(8px) desktop-vw(16px);
+      border-radius: desktop-vw(4px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-contrast);
+      outline-offset: 2px;
+    }
+  }
+
+  .cancel {
+    background-color: transparent;
+    color: var(--color-secondary);
+    border: 1px solid var(--color-secondary);
+
+    @media (--hover) {
+      &:hover {
+        background-color: var(--color-secondary);
+        color: var(--color-primary);
+      }
+    }
+  }
+
+  .confirm {
+    background-color: var(--color-contrast);
+    color: var(--color-primary);
+
+    @media (--hover) {
+      &:hover {
+        opacity: 0.9;
+      }
+    }
+
+    &.destructive {
+      background-color: oklch(0.577 0.2152 27.33);
+    }
   }
 }

--- a/components/ui/checkbox/checkbox.module.css
+++ b/components/ui/checkbox/checkbox.module.css
@@ -1,61 +1,63 @@
-.container {
-  display: flex;
-  align-items: center;
-  gap: mobile-vw(8px);
-  cursor: pointer;
+@layer components {
+  .container {
+    display: flex;
+    align-items: center;
+    gap: mobile-vw(8px);
+    cursor: pointer;
 
-  @media (--desktop) {
-    gap: desktop-vw(8px);
-  }
-}
-
-.label {
-  color: var(--color-secondary);
-  font-size: inherit;
-  user-select: none;
-}
-
-.root {
-  width: mobile-vw(20px);
-  height: mobile-vw(20px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 2px solid var(--color-secondary);
-  border-radius: mobile-vw(4px);
-  background-color: transparent;
-  cursor: pointer;
-  transition:
-    background-color 150ms ease,
-    border-color 150ms ease;
-  flex-shrink: 0;
-
-  @media (--desktop) {
-    width: desktop-vw(20px);
-    height: desktop-vw(20px);
-    border-radius: desktop-vw(4px);
+    @media (--desktop) {
+      gap: desktop-vw(8px);
+    }
   }
 
-  &:focus-visible {
-    outline: 2px solid var(--color-contrast);
-    outline-offset: 2px;
+  .label {
+    color: var(--color-secondary);
+    font-size: inherit;
+    user-select: none;
   }
 
-  &[data-checked],
-  &[data-indeterminate] {
-    background-color: var(--color-contrast);
-    border-color: var(--color-contrast);
+  .root {
+    width: mobile-vw(20px);
+    height: mobile-vw(20px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid var(--color-secondary);
+    border-radius: mobile-vw(4px);
+    background-color: transparent;
+    cursor: pointer;
+    transition:
+      background-color 150ms ease,
+      border-color 150ms ease;
+    flex-shrink: 0;
+
+    @media (--desktop) {
+      width: desktop-vw(20px);
+      height: desktop-vw(20px);
+      border-radius: desktop-vw(4px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-contrast);
+      outline-offset: 2px;
+    }
+
+    &[data-checked],
+    &[data-indeterminate] {
+      background-color: var(--color-contrast);
+      border-color: var(--color-contrast);
+    }
+
+    &[data-disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
   }
 
-  &[data-disabled] {
-    opacity: 0.5;
-    cursor: not-allowed;
+  .indicator {
+    color: var(--color-primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
-}
-
-.indicator {
-  color: var(--color-primary);
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }

--- a/components/ui/fold/fold.module.css
+++ b/components/ui/fold/fold.module.css
@@ -1,63 +1,65 @@
-.fold {
-  &:not(.isDisabled) {
-    position: relative;
+@layer components {
+  .fold {
+    &:not(.isDisabled) {
+      position: relative;
 
-    &.isOverlay {
-      .overlay {
-        position: absolute;
-        inset: 0;
-        pointer-events: none;
-        background-color: var(--color-primary);
-        opacity: var(--progress, 0);
+      &.isOverlay {
+        .overlay {
+          position: absolute;
+          inset: 0;
+          pointer-events: none;
+          background-color: var(--color-primary);
+          opacity: var(--progress, 0);
+        }
       }
-    }
 
-    .sticky {
-      min-height: 100svh;
-      position: sticky;
-    }
+      .sticky {
+        min-height: 100svh;
+        position: sticky;
+      }
 
-    &.isParallax {
+      &.isParallax {
+        &.isBottom {
+          .sticky {
+            transform: translate3d(0, calc(-5svh * var(--progress, 0)), 0);
+          }
+        }
+
+        &.isTop {
+          .sticky {
+            transform: translate3d(0, calc(5svh * var(--progress, 0)), 0);
+          }
+        }
+      }
+
       &.isBottom {
+        margin-bottom: -100svh;
+
+        &::before {
+          content: '';
+          display: block;
+          min-height: 100svh;
+          visibility: hidden;
+        }
+
         .sticky {
-          transform: translate3d(0, calc(-5svh * var(--progress, 0)), 0);
+          bottom: 0;
         }
       }
 
       &.isTop {
-        .sticky {
-          transform: translate3d(0, calc(5svh * var(--progress, 0)), 0);
+        margin-top: -100svh;
+
+        &::after {
+          content: '';
+          display: block;
+          min-height: 100svh;
+          visibility: hidden;
         }
-      }
-    }
 
-    &.isBottom {
-      margin-bottom: -100svh;
-
-      &::before {
-        content: '';
-        display: block;
-        min-height: 100svh;
-        visibility: hidden;
-      }
-
-      .sticky {
-        bottom: 0;
-      }
-    }
-
-    &.isTop {
-      margin-top: -100svh;
-
-      &::after {
-        content: '';
-        display: block;
-        min-height: 100svh;
-        visibility: hidden;
-      }
-
-      .sticky {
-        top: 0;
+        .sticky {
+          top: 0;
+        }
       }
     }
   }

--- a/components/ui/form/fields/fields.module.css
+++ b/components/ui/form/fields/fields.module.css
@@ -1,137 +1,139 @@
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: mobile-vw(4px);
+@layer components {
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: mobile-vw(4px);
 
-  @media (--desktop) {
-    gap: desktop-vw(4px);
-  }
+    @media (--desktop) {
+      gap: desktop-vw(4px);
+    }
 
-  &.error {
-    .input,
-    .textarea {
-      border-color: oklch(0.577 0.2152 27.33);
+    &.error {
+      .input,
+      .textarea {
+        border-color: oklch(0.577 0.2152 27.33);
+      }
+    }
+
+    &.active {
+      .label {
+        color: var(--color-contrast);
+      }
     }
   }
 
-  &.active {
-    .label {
-      color: var(--color-contrast);
-    }
-  }
-}
-
-.label {
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--color-secondary);
-  transition: color 150ms ease;
-}
-
-.input,
-.textarea {
-  padding: mobile-vw(10px) mobile-vw(12px);
-  border: 1px solid var(--color-secondary);
-  border-radius: mobile-vw(4px);
-  background-color: transparent;
-  color: var(--color-secondary);
-  font-size: inherit;
-  font-family: inherit;
-  transition: border-color 150ms ease;
-  width: 100%;
-
-  @media (--desktop) {
-    padding: desktop-vw(10px) desktop-vw(12px);
-    border-radius: desktop-vw(4px);
-  }
-
-  &::placeholder {
+  .label {
+    font-size: 0.875rem;
+    font-weight: 500;
     color: var(--color-secondary);
-    opacity: 0.5;
+    transition: color 150ms ease;
   }
 
-  &:focus {
-    outline: none;
-    border-color: var(--color-contrast);
-  }
+  .input,
+  .textarea {
+    padding: mobile-vw(10px) mobile-vw(12px);
+    border: 1px solid var(--color-secondary);
+    border-radius: mobile-vw(4px);
+    background-color: transparent;
+    color: var(--color-secondary);
+    font-size: inherit;
+    font-family: inherit;
+    transition: border-color 150ms ease;
+    width: 100%;
 
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-}
+    @media (--desktop) {
+      padding: desktop-vw(10px) desktop-vw(12px);
+      border-radius: desktop-vw(4px);
+    }
 
-.textarea {
-  resize: vertical;
-  min-height: 100px;
-}
+    &::placeholder {
+      color: var(--color-secondary);
+      opacity: 0.5;
+    }
 
-.errorMessage {
-  font-size: 0.75rem;
-  color: oklch(0.577 0.2152 27.33);
-  margin-top: mobile-vw(2px);
-
-  @media (--desktop) {
-    margin-top: desktop-vw(2px);
-  }
-}
-
-/* Checkbox group */
-.checkboxGroup {
-  gap: mobile-vw(8px);
-
-  @media (--desktop) {
-    gap: desktop-vw(8px);
-  }
-}
-
-.groupLabel {
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--color-secondary);
-}
-
-.options {
-  display: flex;
-  flex-wrap: wrap;
-  gap: mobile-vw(8px);
-
-  @media (--desktop) {
-    gap: desktop-vw(8px);
-  }
-}
-
-.option {
-  display: flex;
-  align-items: center;
-  gap: mobile-vw(8px);
-  padding: mobile-vw(6px) mobile-vw(12px);
-  border: 1px solid var(--color-secondary);
-  border-radius: mobile-vw(4px);
-  background-color: transparent;
-  color: var(--color-secondary);
-  font-size: 0.875rem;
-  cursor: pointer;
-  transition:
-    background-color 150ms ease,
-    color 150ms ease,
-    border-color 150ms ease;
-
-  @media (--desktop) {
-    gap: desktop-vw(8px);
-    padding: desktop-vw(6px) desktop-vw(12px);
-    border-radius: desktop-vw(4px);
-  }
-
-  @media (--hover) {
-    &:hover {
+    &:focus {
+      outline: none;
       border-color: var(--color-contrast);
     }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
   }
 
-  &.selected {
-    background-color: var(--color-contrast);
-    border-color: var(--color-contrast);
-    color: var(--color-primary);
+  .textarea {
+    resize: vertical;
+    min-height: 100px;
+  }
+
+  .errorMessage {
+    font-size: 0.75rem;
+    color: oklch(0.577 0.2152 27.33);
+    margin-top: mobile-vw(2px);
+
+    @media (--desktop) {
+      margin-top: desktop-vw(2px);
+    }
+  }
+
+  /* Checkbox group */
+  .checkboxGroup {
+    gap: mobile-vw(8px);
+
+    @media (--desktop) {
+      gap: desktop-vw(8px);
+    }
+  }
+
+  .groupLabel {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-secondary);
+  }
+
+  .options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: mobile-vw(8px);
+
+    @media (--desktop) {
+      gap: desktop-vw(8px);
+    }
+  }
+
+  .option {
+    display: flex;
+    align-items: center;
+    gap: mobile-vw(8px);
+    padding: mobile-vw(6px) mobile-vw(12px);
+    border: 1px solid var(--color-secondary);
+    border-radius: mobile-vw(4px);
+    background-color: transparent;
+    color: var(--color-secondary);
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition:
+      background-color 150ms ease,
+      color 150ms ease,
+      border-color 150ms ease;
+
+    @media (--desktop) {
+      gap: desktop-vw(8px);
+      padding: desktop-vw(6px) desktop-vw(12px);
+      border-radius: desktop-vw(4px);
+    }
+
+    @media (--hover) {
+      &:hover {
+        border-color: var(--color-contrast);
+      }
+    }
+
+    &.selected {
+      background-color: var(--color-contrast);
+      border-color: var(--color-contrast);
+      color: var(--color-primary);
+    }
   }
 }

--- a/components/ui/form/form.module.css
+++ b/components/ui/form/form.module.css
@@ -1,74 +1,76 @@
-.submit {
-  position: relative;
-  background-color: var(--color-secondary);
-  color: var(--color-primary);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  &.disabled {
-    pointer-events: none;
-    background-color: var(--color-secondary);
-    color: oklch(0 0 0 / 0.25);
-    opacity: 0.5;
-  }
-
-  &.submitted {
-    pointer-events: none;
-    background: var(--color-green);
-  }
-
-  &.error {
-    pointer-events: none;
-    background: var(--color-white);
-  }
-
-  &.pending {
-    pointer-events: none;
-    opacity: 0.7;
-  }
-
-  span {
+@layer components {
+  .submit {
     position: relative;
-    text-align: center;
-  }
+    background-color: var(--color-secondary);
+    color: var(--color-primary);
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
-  &::before {
-    content: '';
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 100%;
-    height: 100%;
-    background-color: var(--color-black);
-    clip-path: circle(0%);
-  }
+    &.disabled {
+      pointer-events: none;
+      background-color: var(--color-secondary);
+      color: oklch(0 0 0 / 0.25);
+      opacity: 0.5;
+    }
 
-  @media (--hover) {
-    &:hover {
-      color: var(--color-white);
+    &.submitted {
+      pointer-events: none;
+      background: var(--color-green);
+    }
 
-      &::before {
-        transition: 1000ms clip-path var(--ease-gleasing);
-        clip-path: circle(100%);
+    &.error {
+      pointer-events: none;
+      background: var(--color-white);
+    }
+
+    &.pending {
+      pointer-events: none;
+      opacity: 0.7;
+    }
+
+    span {
+      position: relative;
+      text-align: center;
+    }
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 100%;
+      height: 100%;
+      background-color: var(--color-black);
+      clip-path: circle(0%);
+    }
+
+    @media (--hover) {
+      &:hover {
+        color: var(--color-white);
+
+        &::before {
+          transition: 1000ms clip-path var(--ease-gleasing);
+          clip-path: circle(100%);
+        }
       }
     }
   }
-}
 
-.messages {
-  display: flex;
-  flex-direction: column;
-  font-size: mobile-vw(8px);
-  padding-right: mobile-vw(16px);
+  .messages {
+    display: flex;
+    flex-direction: column;
+    font-size: mobile-vw(8px);
+    padding-right: mobile-vw(16px);
 
-  @media (--desktop) {
-    font-size: desktop-vw(14px);
-    padding-right: desktop-vw(16px);
-  }
+    @media (--desktop) {
+      font-size: desktop-vw(14px);
+      padding-right: desktop-vw(16px);
+    }
 
-  .error {
-    color: var(--color-white);
+    .error {
+      color: var(--color-white);
+    }
   }
 }

--- a/components/ui/image/image.module.css
+++ b/components/ui/image/image.module.css
@@ -1,7 +1,9 @@
-.block {
-  width: auto;
-  height: auto;
-  display: block;
+@layer components {
+  .block {
+    width: auto;
+    height: auto;
+    display: block;
+  }
 }
 
 /*

--- a/components/ui/marquee/marquee.module.css
+++ b/components/ui/marquee/marquee.module.css
@@ -1,14 +1,16 @@
-.marquee {
-  display: flex;
-  overflow-x: clip;
-
-  .inner {
+@layer components {
+  .marquee {
     display: flex;
-    white-space: nowrap;
-    transform: translate3d(0, 0, 0);
+    overflow-x: clip;
 
-    > * {
-      flex-shrink: 0;
+    .inner {
+      display: flex;
+      white-space: nowrap;
+      transform: translate3d(0, 0, 0);
+
+      > * {
+        flex-shrink: 0;
+      }
     }
   }
 }

--- a/components/ui/menu/menu.module.css
+++ b/components/ui/menu/menu.module.css
@@ -1,118 +1,120 @@
-.trigger {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: mobile-vw(8px);
-  padding: mobile-vw(8px) mobile-vw(12px);
-  border-radius: mobile-vw(2px);
-  border: 1px solid currentColor;
-  background-color: var(--color-primary);
-  color: var(--color-secondary);
-  cursor: pointer;
+@layer components {
+  .trigger {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: mobile-vw(8px);
+    padding: mobile-vw(8px) mobile-vw(12px);
+    border-radius: mobile-vw(2px);
+    border: 1px solid currentColor;
+    background-color: var(--color-primary);
+    color: var(--color-secondary);
+    cursor: pointer;
 
-  @media (--desktop) {
-    gap: desktop-vw(8px);
-    padding: desktop-vw(8px) desktop-vw(12px);
-    border-radius: desktop-vw(2px);
-  }
-}
-
-.popup {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  min-width: var(--anchor-width);
-  background-color: var(--color-primary);
-  border: 1px solid var(--color-secondary);
-  border-radius: mobile-vw(2px);
-  overflow: clip;
-  padding: mobile-vw(4px);
-  outline: none;
-  z-index: 50;
-
-  /* Base UI animation states */
-  transform-origin: var(--transform-origin);
-  transition:
-    transform 150ms ease-out,
-    opacity 150ms ease-out;
-  opacity: 1;
-  transform: scale(1);
-
-  &[data-starting-style],
-  &[data-ending-style] {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-
-  @media (--desktop) {
-    border-radius: desktop-vw(2px);
-    padding: desktop-vw(4px);
-  }
-}
-
-.item {
-  color: var(--color-secondary);
-  padding: mobile-vw(8px) mobile-vw(12px);
-  position: relative;
-  text-align: left;
-  white-space: nowrap;
-  display: block;
-  width: 100%;
-  border-radius: mobile-vw(2px);
-  cursor: pointer;
-  outline: none;
-  background: transparent;
-  border: none;
-
-  @media (--desktop) {
-    padding: desktop-vw(8px) desktop-vw(12px);
-    border-radius: desktop-vw(2px);
-  }
-
-  @media (--hover) {
-    &:hover,
-    &[data-highlighted] {
-      background-color: var(--color-contrast);
-      color: var(--color-primary);
+    @media (--desktop) {
+      gap: desktop-vw(8px);
+      padding: desktop-vw(8px) desktop-vw(12px);
+      border-radius: desktop-vw(2px);
     }
   }
 
-  &:focus-visible {
-    background-color: var(--color-contrast);
-    color: var(--color-primary);
+  .popup {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    min-width: var(--anchor-width);
+    background-color: var(--color-primary);
+    border: 1px solid var(--color-secondary);
+    border-radius: mobile-vw(2px);
+    overflow: clip;
+    padding: mobile-vw(4px);
+    outline: none;
+    z-index: 50;
+
+    /* Base UI animation states */
+    transform-origin: var(--transform-origin);
+    transition:
+      transform 150ms ease-out,
+      opacity 150ms ease-out;
+    opacity: 1;
+    transform: scale(1);
+
+    &[data-starting-style],
+    &[data-ending-style] {
+      opacity: 0;
+      transform: scale(0.95);
+    }
+
+    @media (--desktop) {
+      border-radius: desktop-vw(2px);
+      padding: desktop-vw(4px);
+    }
   }
 
-  &[data-disabled] {
-    opacity: 0.5;
-    cursor: not-allowed;
+  .item {
+    color: var(--color-secondary);
+    padding: mobile-vw(8px) mobile-vw(12px);
+    position: relative;
+    text-align: left;
+    white-space: nowrap;
+    display: block;
+    width: 100%;
+    border-radius: mobile-vw(2px);
+    cursor: pointer;
+    outline: none;
+    background: transparent;
+    border: none;
+
+    @media (--desktop) {
+      padding: desktop-vw(8px) desktop-vw(12px);
+      border-radius: desktop-vw(2px);
+    }
+
+    @media (--hover) {
+      &:hover,
+      &[data-highlighted] {
+        background-color: var(--color-contrast);
+        color: var(--color-primary);
+      }
+    }
+
+    &:focus-visible {
+      background-color: var(--color-contrast);
+      color: var(--color-primary);
+    }
+
+    &[data-disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
   }
-}
 
-.separator {
-  height: 1px;
-  border: none;
-  background-color: var(--color-secondary);
-  opacity: 0.2;
-  margin: mobile-vw(4px) 0;
+  .separator {
+    height: 1px;
+    border: none;
+    background-color: var(--color-secondary);
+    opacity: 0.2;
+    margin: mobile-vw(4px) 0;
 
-  @media (--desktop) {
-    margin: desktop-vw(4px) 0;
+    @media (--desktop) {
+      margin: desktop-vw(4px) 0;
+    }
   }
-}
 
-.arrow {
-  transition: transform 150ms ease-out;
+  .arrow {
+    transition: transform 150ms ease-out;
 
-  [data-open] & {
-    transform: rotate(180deg);
+    [data-open] & {
+      transform: rotate(180deg);
+    }
   }
-}
 
-.icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 1em;
-  height: 1em;
+  .icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1em;
+    height: 1em;
+  }
 }

--- a/components/ui/not-configured/not-configured.module.css
+++ b/components/ui/not-configured/not-configured.module.css
@@ -1,256 +1,258 @@
-.container {
-  display: flex;
-  flex-grow: 1;
-  align-items: center;
-  justify-content: center;
-  padding: calc(80 / 375 * 100vw) calc(20 / 375 * 100vw);
+@layer components {
+  .container {
+    display: flex;
+    flex-grow: 1;
+    align-items: center;
+    justify-content: center;
+    padding: calc(80 / 375 * 100vw) calc(20 / 375 * 100vw);
 
-  @media (--desktop) {
-    padding: calc(120 / 1440 * 100vw) 0;
-  }
-}
-
-.panel {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  max-width: calc(460 / 375 * 100vw);
-  background: var(--surface);
-  border: 1px solid var(--line-strong);
-  border-radius: calc(6 / 375 * 100vw);
-  overflow: hidden;
-
-  @media (--desktop) {
-    max-width: calc(560 / 1440 * 100vw);
-    border-radius: calc(6 / 1440 * 100vw);
-  }
-}
-
-/* ---- Meta block ---- */
-
-.meta {
-  padding: calc(28 / 375 * 100vw) calc(24 / 375 * 100vw);
-  border-bottom: 1px solid var(--line);
-
-  @media (--desktop) {
-    padding: calc(36 / 1440 * 100vw) calc(32 / 1440 * 100vw);
-  }
-}
-
-.label {
-  font-family: var(--font-mono);
-  font-size: calc(9 / 375 * 100vw);
-  font-weight: 400;
-  letter-spacing: 0.15em;
-  text-transform: uppercase;
-  /* 0.45 rendered #858585 on the panel's --surface (#f2f2f2 in the light-theme
-     fallback) — 3.29:1, under WCAG AA's 4.5:1 (e2e axe pass on /sanity's
-     unconfigured variant). 0.56 renders ≈#666666 — 4.83:1, still muted. */
-  opacity: 0.56;
-  margin-bottom: calc(10 / 375 * 100vw);
-
-  @media (--desktop) {
-    font-size: calc(11 / 1440 * 100vw);
-    margin-bottom: calc(12 / 1440 * 100vw);
-  }
-}
-
-.title {
-  font-family: var(--font-mono);
-  font-size: calc(22 / 375 * 100vw);
-  font-weight: 400;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  line-height: 1;
-  color: var(--color-secondary);
-  margin-bottom: calc(10 / 375 * 100vw);
-
-  @media (--desktop) {
-    font-size: calc(32 / 1440 * 100vw);
-    margin-bottom: calc(12 / 1440 * 100vw);
-  }
-}
-
-.accent {
-  color: var(--color-contrast);
-}
-
-.description {
-  font-family: var(--font-mono);
-  font-size: calc(11 / 375 * 100vw);
-  line-height: 1.6;
-  /* Same fix as .label above: 0.45 was 3.29:1 on --surface, 0.56 is 4.83:1. */
-  opacity: 0.56;
-
-  @media (--desktop) {
-    font-size: calc(12 / 1440 * 100vw);
-  }
-}
-
-/* ---- Instructions block ---- */
-
-.instructions {
-  padding: calc(24 / 375 * 100vw) calc(24 / 375 * 100vw);
-  border-bottom: 1px solid var(--line);
-  /* var(--color-contrast) (the red token, #e9161a) is 4.08:1 on the panel's
-     --surface (#f2f2f2) and only 3.59:1 on the envBlock's --surface-2
-     (#e4e4e4) — both under WCAG AA's 4.5:1 (e2e axe pass on /sanity's
-     unconfigured variant). The red is meaningful here (the shared accent
-     used on .accent, .instructionsLabel, and .envVar), so darken it locally
-     rather than dropping the color. #c41317 is 5.43:1 on #f2f2f2 and 4.78:1
-     on #e4e4e4 — both clear 4.5. Scoped here (not on .instructionsLabel
-     alone) so .envVar, a sibling descendant of this container, can use it
-     too. The global --color-red token is untouched. */
-  --accent-readable: oklch(52.16% 0.2047 27.69);
-
-  @media (--desktop) {
-    padding: calc(28 / 1440 * 100vw) calc(32 / 1440 * 100vw);
-  }
-}
-
-.instructionsLabel {
-  font-family: var(--font-mono);
-  font-size: calc(9 / 375 * 100vw);
-  font-weight: 400;
-  letter-spacing: 0.15em;
-  text-transform: uppercase;
-  color: var(--accent-readable);
-  margin-bottom: calc(14 / 375 * 100vw);
-
-  @media (--desktop) {
-    font-size: calc(10 / 1440 * 100vw);
-    margin-bottom: calc(16 / 1440 * 100vw);
-  }
-}
-
-.steps,
-.stepsAfter {
-  list-style: decimal;
-  padding-left: calc(18 / 375 * 100vw);
-  margin: 0;
-  font-family: var(--font-mono);
-  font-size: calc(11 / 375 * 100vw);
-  line-height: 1.6;
-  opacity: 0.7;
-
-  @media (--desktop) {
-    padding-left: calc(20 / 1440 * 100vw);
-    font-size: calc(12 / 1440 * 100vw);
-  }
-}
-
-.steps li {
-  margin-bottom: calc(8 / 375 * 100vw);
-
-  @media (--desktop) {
-    margin-bottom: calc(8 / 1440 * 100vw);
-  }
-}
-
-.stepsAfter {
-  margin-top: calc(10 / 375 * 100vw);
-
-  @media (--desktop) {
-    margin-top: calc(12 / 1440 * 100vw);
-  }
-}
-
-/* ---- Env vars block ---- */
-
-.envBlock {
-  display: flex;
-  flex-direction: column;
-  gap: calc(4 / 375 * 100vw);
-  margin-top: calc(10 / 375 * 100vw);
-  padding: calc(12 / 375 * 100vw) calc(14 / 375 * 100vw);
-  background: var(--surface-2);
-  border: 1px solid var(--line);
-  border-radius: calc(4 / 375 * 100vw);
-
-  @media (--desktop) {
-    gap: calc(5 / 1440 * 100vw);
-    margin-top: calc(10 / 1440 * 100vw);
-    padding: calc(14 / 1440 * 100vw) calc(16 / 1440 * 100vw);
-    border-radius: calc(4 / 1440 * 100vw);
-  }
-}
-
-.envVar {
-  font-family: var(--font-mono);
-  font-size: calc(10 / 375 * 100vw);
-  /* See --accent-readable comment on .instructions above: var(--color-contrast)
-     is 3.59:1 on this element's envBlock (--surface-2, #e4e4e4) — under
-     WCAG AA. --accent-readable is 4.78:1 on #e4e4e4. */
-  color: var(--accent-readable);
-
-  @media (--desktop) {
-    font-size: calc(12 / 1440 * 100vw);
-  }
-}
-
-.code {
-  font-family: var(--font-mono);
-  font-size: 0.9em;
-  background: var(--surface-2);
-  padding: 0.1em 0.3em;
-  border-radius: 2px;
-  border: 1px solid var(--line);
-}
-
-/* ---- Footer block ---- */
-
-.footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: calc(16 / 375 * 100vw);
-  padding: calc(18 / 375 * 100vw) calc(24 / 375 * 100vw);
-  background: var(--surface-2);
-
-  @media (--desktop) {
-    padding: calc(20 / 1440 * 100vw) calc(32 / 1440 * 100vw);
-  }
-}
-
-.hint {
-  font-family: var(--font-mono);
-  font-size: calc(10 / 375 * 100vw);
-  /* Sits on .footer's --surface-2 (#e4e4e4), darker than the --surface
-     (#f2f2f2) .label/.description are tuned against above — 0.45 rendered
-     #7d7d7d here, 3.23:1, under WCAG AA (e2e axe pass; this also darkens
-     the nested .code child via the same opacity blend, since opacity
-     composites the whole subtree). 0.56 renders ~#646464 on #e4e4e4 —
-     5.17:1, still muted. Tuned independently for this surface; not coupled
-     to .label/.description's 0.56 even though the number matches. */
-  opacity: 0.56;
-  line-height: 1.5;
-
-  @media (--desktop) {
-    font-size: calc(11 / 1440 * 100vw);
-  }
-}
-
-.docsLink {
-  display: inline-flex;
-  flex-shrink: 0;
-  align-items: center;
-  gap: calc(5 / 375 * 100vw);
-  font-family: var(--font-mono);
-  font-size: calc(10 / 375 * 100vw);
-  font-weight: 400;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  text-decoration: none;
-  color: var(--color-secondary);
-  opacity: 0.7;
-  transition: opacity var(--duration-fast) ease;
-
-  &:hover {
-    opacity: 1;
+    @media (--desktop) {
+      padding: calc(120 / 1440 * 100vw) 0;
+    }
   }
 
-  @media (--desktop) {
-    gap: calc(6 / 1440 * 100vw);
-    font-size: calc(11 / 1440 * 100vw);
+  .panel {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: calc(460 / 375 * 100vw);
+    background: var(--surface);
+    border: 1px solid var(--line-strong);
+    border-radius: calc(6 / 375 * 100vw);
+    overflow: hidden;
+
+    @media (--desktop) {
+      max-width: calc(560 / 1440 * 100vw);
+      border-radius: calc(6 / 1440 * 100vw);
+    }
+  }
+
+  /* ---- Meta block ---- */
+
+  .meta {
+    padding: calc(28 / 375 * 100vw) calc(24 / 375 * 100vw);
+    border-bottom: 1px solid var(--line);
+
+    @media (--desktop) {
+      padding: calc(36 / 1440 * 100vw) calc(32 / 1440 * 100vw);
+    }
+  }
+
+  .label {
+    font-family: var(--font-mono);
+    font-size: calc(9 / 375 * 100vw);
+    font-weight: 400;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    /* 0.45 rendered #858585 on the panel's --surface (#f2f2f2 in the light-theme
+       fallback) — 3.29:1, under WCAG AA's 4.5:1 (e2e axe pass on /sanity's
+       unconfigured variant). 0.56 renders ≈#666666 — 4.83:1, still muted. */
+    opacity: 0.56;
+    margin-bottom: calc(10 / 375 * 100vw);
+
+    @media (--desktop) {
+      font-size: calc(11 / 1440 * 100vw);
+      margin-bottom: calc(12 / 1440 * 100vw);
+    }
+  }
+
+  .title {
+    font-family: var(--font-mono);
+    font-size: calc(22 / 375 * 100vw);
+    font-weight: 400;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    line-height: 1;
+    color: var(--color-secondary);
+    margin-bottom: calc(10 / 375 * 100vw);
+
+    @media (--desktop) {
+      font-size: calc(32 / 1440 * 100vw);
+      margin-bottom: calc(12 / 1440 * 100vw);
+    }
+  }
+
+  .accent {
+    color: var(--color-contrast);
+  }
+
+  .description {
+    font-family: var(--font-mono);
+    font-size: calc(11 / 375 * 100vw);
+    line-height: 1.6;
+    /* Same fix as .label above: 0.45 was 3.29:1 on --surface, 0.56 is 4.83:1. */
+    opacity: 0.56;
+
+    @media (--desktop) {
+      font-size: calc(12 / 1440 * 100vw);
+    }
+  }
+
+  /* ---- Instructions block ---- */
+
+  .instructions {
+    padding: calc(24 / 375 * 100vw) calc(24 / 375 * 100vw);
+    border-bottom: 1px solid var(--line);
+    /* var(--color-contrast) (the red token, #e9161a) is 4.08:1 on the panel's
+       --surface (#f2f2f2) and only 3.59:1 on the envBlock's --surface-2
+       (#e4e4e4) — both under WCAG AA's 4.5:1 (e2e axe pass on /sanity's
+       unconfigured variant). The red is meaningful here (the shared accent
+       used on .accent, .instructionsLabel, and .envVar), so darken it locally
+       rather than dropping the color. #c41317 is 5.43:1 on #f2f2f2 and 4.78:1
+       on #e4e4e4 — both clear 4.5. Scoped here (not on .instructionsLabel
+       alone) so .envVar, a sibling descendant of this container, can use it
+       too. The global --color-red token is untouched. */
+    --accent-readable: oklch(52.16% 0.2047 27.69);
+
+    @media (--desktop) {
+      padding: calc(28 / 1440 * 100vw) calc(32 / 1440 * 100vw);
+    }
+  }
+
+  .instructionsLabel {
+    font-family: var(--font-mono);
+    font-size: calc(9 / 375 * 100vw);
+    font-weight: 400;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--accent-readable);
+    margin-bottom: calc(14 / 375 * 100vw);
+
+    @media (--desktop) {
+      font-size: calc(10 / 1440 * 100vw);
+      margin-bottom: calc(16 / 1440 * 100vw);
+    }
+  }
+
+  .steps,
+  .stepsAfter {
+    list-style: decimal;
+    padding-left: calc(18 / 375 * 100vw);
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: calc(11 / 375 * 100vw);
+    line-height: 1.6;
+    opacity: 0.7;
+
+    @media (--desktop) {
+      padding-left: calc(20 / 1440 * 100vw);
+      font-size: calc(12 / 1440 * 100vw);
+    }
+  }
+
+  .steps li {
+    margin-bottom: calc(8 / 375 * 100vw);
+
+    @media (--desktop) {
+      margin-bottom: calc(8 / 1440 * 100vw);
+    }
+  }
+
+  .stepsAfter {
+    margin-top: calc(10 / 375 * 100vw);
+
+    @media (--desktop) {
+      margin-top: calc(12 / 1440 * 100vw);
+    }
+  }
+
+  /* ---- Env vars block ---- */
+
+  .envBlock {
+    display: flex;
+    flex-direction: column;
+    gap: calc(4 / 375 * 100vw);
+    margin-top: calc(10 / 375 * 100vw);
+    padding: calc(12 / 375 * 100vw) calc(14 / 375 * 100vw);
+    background: var(--surface-2);
+    border: 1px solid var(--line);
+    border-radius: calc(4 / 375 * 100vw);
+
+    @media (--desktop) {
+      gap: calc(5 / 1440 * 100vw);
+      margin-top: calc(10 / 1440 * 100vw);
+      padding: calc(14 / 1440 * 100vw) calc(16 / 1440 * 100vw);
+      border-radius: calc(4 / 1440 * 100vw);
+    }
+  }
+
+  .envVar {
+    font-family: var(--font-mono);
+    font-size: calc(10 / 375 * 100vw);
+    /* See --accent-readable comment on .instructions above: var(--color-contrast)
+       is 3.59:1 on this element's envBlock (--surface-2, #e4e4e4) — under
+       WCAG AA. --accent-readable is 4.78:1 on #e4e4e4. */
+    color: var(--accent-readable);
+
+    @media (--desktop) {
+      font-size: calc(12 / 1440 * 100vw);
+    }
+  }
+
+  .code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--surface-2);
+    padding: 0.1em 0.3em;
+    border-radius: 2px;
+    border: 1px solid var(--line);
+  }
+
+  /* ---- Footer block ---- */
+
+  .footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: calc(16 / 375 * 100vw);
+    padding: calc(18 / 375 * 100vw) calc(24 / 375 * 100vw);
+    background: var(--surface-2);
+
+    @media (--desktop) {
+      padding: calc(20 / 1440 * 100vw) calc(32 / 1440 * 100vw);
+    }
+  }
+
+  .hint {
+    font-family: var(--font-mono);
+    font-size: calc(10 / 375 * 100vw);
+    /* Sits on .footer's --surface-2 (#e4e4e4), darker than the --surface
+       (#f2f2f2) .label/.description are tuned against above — 0.45 rendered
+       #7d7d7d here, 3.23:1, under WCAG AA (e2e axe pass; this also darkens
+       the nested .code child via the same opacity blend, since opacity
+       composites the whole subtree). 0.56 renders ~#646464 on #e4e4e4 —
+       5.17:1, still muted. Tuned independently for this surface; not coupled
+       to .label/.description's 0.56 even though the number matches. */
+    opacity: 0.56;
+    line-height: 1.5;
+
+    @media (--desktop) {
+      font-size: calc(11 / 1440 * 100vw);
+    }
+  }
+
+  .docsLink {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: calc(5 / 375 * 100vw);
+    font-family: var(--font-mono);
+    font-size: calc(10 / 375 * 100vw);
+    font-weight: 400;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    text-decoration: none;
+    color: var(--color-secondary);
+    opacity: 0.7;
+    transition: opacity var(--duration-fast) ease;
+
+    &:hover {
+      opacity: 1;
+    }
+
+    @media (--desktop) {
+      gap: calc(6 / 1440 * 100vw);
+      font-size: calc(11 / 1440 * 100vw);
+    }
   }
 }

--- a/components/ui/select/select.module.css
+++ b/components/ui/select/select.module.css
@@ -1,94 +1,96 @@
-.label {
-  display: block;
-  margin-bottom: mobile-vw(4px);
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--color-secondary);
+@layer components {
+  .label {
+    display: block;
+    margin-bottom: mobile-vw(4px);
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-secondary);
 
-  @media (--desktop) {
-    margin-bottom: desktop-vw(4px);
-  }
-}
-
-.trigger {
-  box-shadow: 0 1px 2px oklch(0 0 0 / 0.1);
-  display: flex;
-  align-items: center;
-  background-color: var(--color-primary);
-  color: var(--color-secondary);
-  cursor: pointer;
-  transition: border-color 150ms ease;
-
-  &:hover {
-    border-color: var(--color-contrast);
+    @media (--desktop) {
+      margin-bottom: desktop-vw(4px);
+    }
   }
 
-  &:focus-visible {
-    outline: 2px solid var(--color-contrast);
-    outline-offset: 2px;
+  .trigger {
+    box-shadow: 0 1px 2px oklch(0 0 0 / 0.1);
+    display: flex;
+    align-items: center;
+    background-color: var(--color-primary);
+    color: var(--color-secondary);
+    cursor: pointer;
+    transition: border-color 150ms ease;
+
+    &:hover {
+      border-color: var(--color-contrast);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-contrast);
+      outline-offset: 2px;
+    }
+
+    &[data-disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
   }
 
-  &[data-disabled] {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-}
+  .popup {
+    background-color: var(--color-primary);
+    border: 1px solid var(--color-secondary);
+    border-radius: mobile-vw(4px);
+    padding: mobile-vw(4px);
+    box-shadow: 0 4px 12px oklch(0 0 0 / 0.15);
+    outline: none;
+    z-index: 50;
+    max-height: 300px;
+    overflow-y: auto;
 
-.popup {
-  background-color: var(--color-primary);
-  border: 1px solid var(--color-secondary);
-  border-radius: mobile-vw(4px);
-  padding: mobile-vw(4px);
-  box-shadow: 0 4px 12px oklch(0 0 0 / 0.15);
-  outline: none;
-  z-index: 50;
-  max-height: 300px;
-  overflow-y: auto;
+    /* Base UI animation states */
+    transform-origin: var(--transform-origin);
+    transition:
+      transform 150ms ease-out,
+      opacity 150ms ease-out;
+    opacity: 1;
+    transform: scale(1);
 
-  /* Base UI animation states */
-  transform-origin: var(--transform-origin);
-  transition:
-    transform 150ms ease-out,
-    opacity 150ms ease-out;
-  opacity: 1;
-  transform: scale(1);
+    &[data-starting-style],
+    &[data-ending-style] {
+      opacity: 0;
+      transform: scale(0.95);
+    }
 
-  &[data-starting-style],
-  &[data-ending-style] {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-
-  @media (--desktop) {
-    border-radius: desktop-vw(4px);
-    padding: desktop-vw(4px);
-  }
-}
-
-.option {
-  min-width: var(--anchor-width);
-  cursor: default;
-  grid-template-columns: 0.75rem 1fr;
-  outline: none;
-  border-radius: mobile-vw(2px);
-  color: var(--color-secondary);
-
-  @media (--desktop) {
-    border-radius: desktop-vw(2px);
+    @media (--desktop) {
+      border-radius: desktop-vw(4px);
+      padding: desktop-vw(4px);
+    }
   }
 
-  &[data-side='none'] {
-    min-width: calc(var(--anchor-width) + 1rem);
-    padding-right: 1rem;
-  }
+  .option {
+    min-width: var(--anchor-width);
+    cursor: default;
+    grid-template-columns: 0.75rem 1fr;
+    outline: none;
+    border-radius: mobile-vw(2px);
+    color: var(--color-secondary);
 
-  &[data-highlighted] {
-    background-color: var(--color-contrast);
-    color: var(--color-primary);
-  }
+    @media (--desktop) {
+      border-radius: desktop-vw(2px);
+    }
 
-  &[data-disabled] {
-    opacity: 0.5;
-    cursor: not-allowed;
+    &[data-side='none'] {
+      min-width: calc(var(--anchor-width) + 1rem);
+      padding-right: 1rem;
+    }
+
+    &[data-highlighted] {
+      background-color: var(--color-contrast);
+      color: var(--color-primary);
+    }
+
+    &[data-disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
   }
 }

--- a/components/ui/switch/switch.module.css
+++ b/components/ui/switch/switch.module.css
@@ -1,77 +1,79 @@
-.container {
-  display: flex;
-  align-items: center;
-  gap: mobile-vw(8px);
-  cursor: pointer;
-
-  @media (--desktop) {
-    gap: desktop-vw(8px);
-  }
-}
-
-.label {
-  color: var(--color-secondary);
-  font-size: inherit;
-  user-select: none;
-}
-
-.root {
-  position: relative;
-  width: mobile-vw(44px);
-  height: mobile-vw(24px);
-  padding: mobile-vw(2px);
-  background-color: var(--color-secondary);
-  opacity: 0.3;
-  border-radius: mobile-vw(12px);
-  border: none;
-  cursor: pointer;
-  transition:
-    background-color 150ms ease,
-    opacity 150ms ease;
-  flex-shrink: 0;
-
-  @media (--desktop) {
-    width: desktop-vw(44px);
-    height: desktop-vw(24px);
-    padding: desktop-vw(2px);
-    border-radius: desktop-vw(12px);
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--color-contrast);
-    outline-offset: 2px;
-  }
-
-  &[data-checked] {
-    background-color: var(--color-contrast);
-    opacity: 1;
-  }
-
-  &[data-disabled] {
-    opacity: 0.2;
-    cursor: not-allowed;
-  }
-}
-
-.thumb {
-  display: block;
-  width: mobile-vw(20px);
-  height: mobile-vw(20px);
-  background-color: var(--color-primary);
-  border-radius: 50%;
-  transition: transform 150ms ease;
-  box-shadow: 0 1px 3px oklch(0 0 0 / 0.2);
-
-  @media (--desktop) {
-    width: desktop-vw(20px);
-    height: desktop-vw(20px);
-  }
-
-  [data-checked] & {
-    transform: translateX(mobile-vw(20px));
+@layer components {
+  .container {
+    display: flex;
+    align-items: center;
+    gap: mobile-vw(8px);
+    cursor: pointer;
 
     @media (--desktop) {
-      transform: translateX(desktop-vw(20px));
+      gap: desktop-vw(8px);
+    }
+  }
+
+  .label {
+    color: var(--color-secondary);
+    font-size: inherit;
+    user-select: none;
+  }
+
+  .root {
+    position: relative;
+    width: mobile-vw(44px);
+    height: mobile-vw(24px);
+    padding: mobile-vw(2px);
+    background-color: var(--color-secondary);
+    opacity: 0.3;
+    border-radius: mobile-vw(12px);
+    border: none;
+    cursor: pointer;
+    transition:
+      background-color 150ms ease,
+      opacity 150ms ease;
+    flex-shrink: 0;
+
+    @media (--desktop) {
+      width: desktop-vw(44px);
+      height: desktop-vw(24px);
+      padding: desktop-vw(2px);
+      border-radius: desktop-vw(12px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-contrast);
+      outline-offset: 2px;
+    }
+
+    &[data-checked] {
+      background-color: var(--color-contrast);
+      opacity: 1;
+    }
+
+    &[data-disabled] {
+      opacity: 0.2;
+      cursor: not-allowed;
+    }
+  }
+
+  .thumb {
+    display: block;
+    width: mobile-vw(20px);
+    height: mobile-vw(20px);
+    background-color: var(--color-primary);
+    border-radius: 50%;
+    transition: transform 150ms ease;
+    box-shadow: 0 1px 3px oklch(0 0 0 / 0.2);
+
+    @media (--desktop) {
+      width: desktop-vw(20px);
+      height: desktop-vw(20px);
+    }
+
+    [data-checked] & {
+      transform: translateX(mobile-vw(20px));
+
+      @media (--desktop) {
+        transform: translateX(desktop-vw(20px));
+      }
     }
   }
 }

--- a/components/ui/tabs/tabs.module.css
+++ b/components/ui/tabs/tabs.module.css
@@ -1,75 +1,77 @@
-.list {
-  display: flex;
-  gap: mobile-vw(4px);
-  border-bottom: 1px solid var(--color-secondary);
-  padding-bottom: mobile-vw(1px);
-  position: relative;
+@layer components {
+  .list {
+    display: flex;
+    gap: mobile-vw(4px);
+    border-bottom: 1px solid var(--color-secondary);
+    padding-bottom: mobile-vw(1px);
+    position: relative;
 
-  @media (--desktop) {
-    gap: desktop-vw(4px);
-    padding-bottom: desktop-vw(1px);
-  }
-}
-
-.tab {
-  padding: mobile-vw(8px) mobile-vw(16px);
-  background: transparent;
-  border: none;
-  color: var(--color-secondary);
-  cursor: pointer;
-  font-size: inherit;
-  font-family: inherit;
-  opacity: 0.6;
-  transition:
-    opacity 150ms ease,
-    color 150ms ease;
-  position: relative;
-
-  @media (--desktop) {
-    padding: desktop-vw(8px) desktop-vw(16px);
-  }
-
-  @media (--hover) {
-    &:hover {
-      opacity: 0.8;
+    @media (--desktop) {
+      gap: desktop-vw(4px);
+      padding-bottom: desktop-vw(1px);
     }
   }
 
-  &:focus-visible {
-    outline: 2px solid var(--color-contrast);
-    outline-offset: 2px;
+  .tab {
+    padding: mobile-vw(8px) mobile-vw(16px);
+    background: transparent;
+    border: none;
+    color: var(--color-secondary);
+    cursor: pointer;
+    font-size: inherit;
+    font-family: inherit;
+    opacity: 0.6;
+    transition:
+      opacity 150ms ease,
+      color 150ms ease;
+    position: relative;
+
+    @media (--desktop) {
+      padding: desktop-vw(8px) desktop-vw(16px);
+    }
+
+    @media (--hover) {
+      &:hover {
+        opacity: 0.8;
+      }
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-contrast);
+      outline-offset: 2px;
+    }
+
+    &[data-selected] {
+      opacity: 1;
+      color: var(--color-contrast);
+    }
+
+    &[data-disabled] {
+      opacity: 0.3;
+      cursor: not-allowed;
+    }
   }
 
-  &[data-selected] {
-    opacity: 1;
-    color: var(--color-contrast);
+  .indicator {
+    position: absolute;
+    bottom: 0;
+    height: 2px;
+    background-color: var(--color-contrast);
+    transition:
+      left 200ms ease-out,
+      width 200ms ease-out;
   }
 
-  &[data-disabled] {
-    opacity: 0.3;
-    cursor: not-allowed;
-  }
-}
+  .panel {
+    padding: mobile-vw(16px) 0;
 
-.indicator {
-  position: absolute;
-  bottom: 0;
-  height: 2px;
-  background-color: var(--color-contrast);
-  transition:
-    left 200ms ease-out,
-    width 200ms ease-out;
-}
+    @media (--desktop) {
+      padding: desktop-vw(16px) 0;
+    }
 
-.panel {
-  padding: mobile-vw(16px) 0;
-
-  @media (--desktop) {
-    padding: desktop-vw(16px) 0;
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--color-contrast);
-    outline-offset: 2px;
+    &:focus-visible {
+      outline: 2px solid var(--color-contrast);
+      outline-offset: 2px;
+    }
   }
 }

--- a/components/ui/toast/toast.module.css
+++ b/components/ui/toast/toast.module.css
@@ -1,108 +1,110 @@
-.viewport {
-  position: fixed;
-  bottom: mobile-vw(16px);
-  right: mobile-vw(16px);
-  display: flex;
-  flex-direction: column;
-  gap: mobile-vw(8px);
-  z-index: 200;
-  max-width: min(400px, calc(100vw - 32px));
+@layer components {
+  .viewport {
+    position: fixed;
+    bottom: mobile-vw(16px);
+    right: mobile-vw(16px);
+    display: flex;
+    flex-direction: column;
+    gap: mobile-vw(8px);
+    z-index: 200;
+    max-width: min(400px, calc(100vw - 32px));
 
-  @media (--desktop) {
-    bottom: desktop-vw(16px);
-    right: desktop-vw(16px);
-    gap: desktop-vw(8px);
-  }
-}
-
-.root {
-  display: flex;
-  align-items: flex-start;
-  gap: mobile-vw(12px);
-  padding: mobile-vw(12px) mobile-vw(16px);
-  background-color: var(--color-primary);
-  border: 1px solid var(--color-secondary);
-  border-radius: mobile-vw(8px);
-  box-shadow: 0 4px 12px oklch(0 0 0 / 0.15);
-  position: relative;
-
-  /* Base UI animation states */
-  transition:
-    transform 200ms ease-out,
-    opacity 200ms ease-out;
-  opacity: 1;
-  transform: translateX(0);
-
-  &[data-starting-style] {
-    opacity: 0;
-    transform: translateX(100%);
-  }
-
-  &[data-ending-style] {
-    opacity: 0;
-    transform: translateX(100%);
-  }
-
-  @media (--desktop) {
-    gap: desktop-vw(12px);
-    padding: desktop-vw(12px) desktop-vw(16px);
-    border-radius: desktop-vw(8px);
-  }
-
-  /* Toast types */
-  &.success {
-    border-left: 4px solid oklch(0.7227 0.192 149.58);
-  }
-
-  &.error {
-    border-left: 4px solid oklch(0.577 0.2152 27.33);
-  }
-
-  &.info {
-    border-left: 4px solid oklch(0.6231 0.188 259.81);
-  }
-
-  &.default {
-    border-left: 4px solid var(--color-contrast);
-  }
-}
-
-.title {
-  flex: 1;
-  color: var(--color-secondary);
-  font-weight: 500;
-}
-
-.description {
-  color: var(--color-secondary);
-  opacity: 0.7;
-  font-size: 0.875rem;
-  margin-top: mobile-vw(4px);
-
-  @media (--desktop) {
-    margin-top: desktop-vw(4px);
-  }
-}
-
-.close {
-  background: transparent;
-  border: none;
-  color: var(--color-secondary);
-  opacity: 0.5;
-  cursor: pointer;
-  font-size: 1.25rem;
-  line-height: 1;
-  padding: 0;
-  transition: opacity 150ms ease;
-
-  @media (--hover) {
-    &:hover {
-      opacity: 1;
+    @media (--desktop) {
+      bottom: desktop-vw(16px);
+      right: desktop-vw(16px);
+      gap: desktop-vw(8px);
     }
   }
 
-  &:focus-visible {
-    outline: 2px solid var(--color-contrast);
-    outline-offset: 2px;
+  .root {
+    display: flex;
+    align-items: flex-start;
+    gap: mobile-vw(12px);
+    padding: mobile-vw(12px) mobile-vw(16px);
+    background-color: var(--color-primary);
+    border: 1px solid var(--color-secondary);
+    border-radius: mobile-vw(8px);
+    box-shadow: 0 4px 12px oklch(0 0 0 / 0.15);
+    position: relative;
+
+    /* Base UI animation states */
+    transition:
+      transform 200ms ease-out,
+      opacity 200ms ease-out;
+    opacity: 1;
+    transform: translateX(0);
+
+    &[data-starting-style] {
+      opacity: 0;
+      transform: translateX(100%);
+    }
+
+    &[data-ending-style] {
+      opacity: 0;
+      transform: translateX(100%);
+    }
+
+    @media (--desktop) {
+      gap: desktop-vw(12px);
+      padding: desktop-vw(12px) desktop-vw(16px);
+      border-radius: desktop-vw(8px);
+    }
+
+    /* Toast types */
+    &.success {
+      border-left: 4px solid oklch(0.7227 0.192 149.58);
+    }
+
+    &.error {
+      border-left: 4px solid oklch(0.577 0.2152 27.33);
+    }
+
+    &.info {
+      border-left: 4px solid oklch(0.6231 0.188 259.81);
+    }
+
+    &.default {
+      border-left: 4px solid var(--color-contrast);
+    }
+  }
+
+  .title {
+    flex: 1;
+    color: var(--color-secondary);
+    font-weight: 500;
+  }
+
+  .description {
+    color: var(--color-secondary);
+    opacity: 0.7;
+    font-size: 0.875rem;
+    margin-top: mobile-vw(4px);
+
+    @media (--desktop) {
+      margin-top: desktop-vw(4px);
+    }
+  }
+
+  .close {
+    background: transparent;
+    border: none;
+    color: var(--color-secondary);
+    opacity: 0.5;
+    cursor: pointer;
+    font-size: 1.25rem;
+    line-height: 1;
+    padding: 0;
+    transition: opacity 150ms ease;
+
+    @media (--hover) {
+      &:hover {
+        opacity: 1;
+      }
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-contrast);
+      outline-offset: 2px;
+    }
   }
 }

--- a/components/ui/tooltip/tooltip.module.css
+++ b/components/ui/tooltip/tooltip.module.css
@@ -1,49 +1,51 @@
-.popup {
-  background-color: var(--color-secondary);
-  color: var(--color-primary);
-  padding: mobile-vw(6px) mobile-vw(10px);
-  border-radius: mobile-vw(4px);
-  font-size: 0.875rem;
-  max-width: 280px;
-  z-index: 100;
-  box-shadow: 0 2px 8px oklch(0 0 0 / 0.15);
+@layer components {
+  .popup {
+    background-color: var(--color-secondary);
+    color: var(--color-primary);
+    padding: mobile-vw(6px) mobile-vw(10px);
+    border-radius: mobile-vw(4px);
+    font-size: 0.875rem;
+    max-width: 280px;
+    z-index: 100;
+    box-shadow: 0 2px 8px oklch(0 0 0 / 0.15);
 
-  /* Base UI animation states */
-  transform-origin: var(--transform-origin);
-  transition:
-    transform 150ms ease-out,
-    opacity 150ms ease-out;
-  opacity: 1;
-  transform: scale(1);
+    /* Base UI animation states */
+    transform-origin: var(--transform-origin);
+    transition:
+      transform 150ms ease-out,
+      opacity 150ms ease-out;
+    opacity: 1;
+    transform: scale(1);
 
-  &[data-starting-style],
-  &[data-ending-style] {
-    opacity: 0;
-    transform: scale(0.95);
+    &[data-starting-style],
+    &[data-ending-style] {
+      opacity: 0;
+      transform: scale(0.95);
+    }
+
+    @media (--desktop) {
+      padding: desktop-vw(6px) desktop-vw(10px);
+      border-radius: desktop-vw(4px);
+    }
   }
 
-  @media (--desktop) {
-    padding: desktop-vw(6px) desktop-vw(10px);
-    border-radius: desktop-vw(4px);
-  }
-}
+  .arrow {
+    fill: var(--color-secondary);
 
-.arrow {
-  fill: var(--color-secondary);
+    &[data-side='top'] {
+      bottom: -8px;
+    }
 
-  &[data-side='top'] {
-    bottom: -8px;
-  }
+    &[data-side='bottom'] {
+      top: -8px;
+    }
 
-  &[data-side='bottom'] {
-    top: -8px;
-  }
+    &[data-side='left'] {
+      right: -8px;
+    }
 
-  &[data-side='left'] {
-    right: -8px;
-  }
-
-  &[data-side='right'] {
-    left: -8px;
+    &[data-side='right'] {
+      left: -8px;
+    }
   }
 }

--- a/lib/integrations/hubspot/embed/form.module.css
+++ b/lib/integrations/hubspot/embed/form.module.css
@@ -1,451 +1,453 @@
-.hubspot-form {
-  --gray: oklch(0 0 0 / 0.25);
-  padding: 0 mobile-vw(24px);
-
-  @media (--desktop) {
-    padding: 0 desktop-vw(24px);
-  }
-
-  > div:first-child {
-    font-family: var(--font-mono);
-    text-align: center;
-    font-size: mobile-vw(25px);
+@layer components {
+  .hubspot-form {
+    --gray: oklch(0 0 0 / 0.25);
+    padding: 0 mobile-vw(24px);
 
     @media (--desktop) {
-      font-size: desktop-vw(25px);
+      padding: 0 desktop-vw(24px);
     }
-  }
 
-  :global(.hs-email),
-  :global(.hs-phone),
-  :global(.hs-fieldtype-number),
-  :global(.hs-fieldtype-text),
-  :global(.hs-fieldtype-date),
-  :global(.hs-fieldtype-select) {
-    input,
-    select {
-      width: 100% !important;
-      border: 2px solid var(--color-black);
-      padding: mobile-vw(15px) mobile-vw(21px);
-      border-radius: mobile-vw(8px);
+    > div:first-child {
+      font-family: var(--font-mono);
+      text-align: center;
+      font-size: mobile-vw(25px);
 
       @media (--desktop) {
-        font-size: desktop-vw(14px);
-        padding: desktop-vw(10px) desktop-vw(16px);
-        border-radius: desktop-vw(8px);
+        font-size: desktop-vw(25px);
       }
     }
-  }
 
-  :global(.hs-fieldtype-date),
-  :global(.hs-fieldtype-select) {
-    > div:last-of-type {
-      position: relative;
-
-      &::after {
-        content: '';
-        position: absolute;
-        top: 50%;
-        transform: translateY(-50%);
-        right: mobile-vw(10px);
-        width: 5px;
-        height: 5px;
-        border-left: mobile-vw(6px) solid transparent;
-        border-right: mobile-vw(6px) solid transparent;
-        border-top: mobile-vw(6px) solid var(--color-black);
+    :global(.hs-email),
+    :global(.hs-phone),
+    :global(.hs-fieldtype-number),
+    :global(.hs-fieldtype-text),
+    :global(.hs-fieldtype-date),
+    :global(.hs-fieldtype-select) {
+      input,
+      select {
+        width: 100% !important;
+        border: 2px solid var(--color-black);
+        padding: mobile-vw(15px) mobile-vw(21px);
+        border-radius: mobile-vw(8px);
 
         @media (--desktop) {
-          right: desktop-vw(15px);
-          border-left: desktop-vw(6px) solid transparent;
-          border-right: desktop-vw(6px) solid transparent;
-          border-top: desktop-vw(6px) solid var(--color-black);
+          font-size: desktop-vw(14px);
+          padding: desktop-vw(10px) desktop-vw(16px);
+          border-radius: desktop-vw(8px);
         }
       }
     }
-  }
 
-  :global(.hs-fieldtype-textarea) {
-    width: 100%;
-    border-radius: mobile-vw(8px);
-    position: relative;
-    font-family: var(--font-mono);
-    line-height: 150%;
-    color: var(--color-black) !important;
-    min-height: mobile-vw(100px);
-
-    @media (--desktop) {
-      border-radius: desktop-vw(8px);
-      min-height: desktop-vw(100px);
-    }
-
-    textarea {
-      border: 2px solid var(--color-black);
-      padding: mobile-vw(10px);
-      margin-bottom: 0;
-
-      @media (--desktop) {
-        padding: desktop-vw(6px) desktop-vw(16px);
-      }
-    }
-  }
-
-  :global(.hs-fieldtype-checkbox) {
-    width: 100%;
-
-    div > ul {
-      color: var(--color-black);
-      display: flex;
-      flex-direction: column;
-      row-gap: mobile-vw(10px);
-
-      @media (--desktop) {
-        row-gap: desktop-vw(10px);
-      }
-
-      > li {
+    :global(.hs-fieldtype-date),
+    :global(.hs-fieldtype-select) {
+      > div:last-of-type {
         position: relative;
 
-        @media (--hover) {
-          &:hover {
-            input {
-              background-color: var(--color-green);
-              color: var(--color-white);
-            }
-          }
-        }
-
-        > label {
-          display: flex;
-          align-items: center;
-          position: relative;
-          line-height: normal;
-          font-size: mobile-vw(14px);
+        &::after {
+          content: '';
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+          right: mobile-vw(10px);
+          width: 5px;
+          height: 5px;
+          border-left: mobile-vw(6px) solid transparent;
+          border-right: mobile-vw(6px) solid transparent;
+          border-top: mobile-vw(6px) solid var(--color-black);
 
           @media (--desktop) {
-            font-size: desktop-vw(14px);
+            right: desktop-vw(15px);
+            border-left: desktop-vw(6px) solid transparent;
+            border-right: desktop-vw(6px) solid transparent;
+            border-top: desktop-vw(6px) solid var(--color-black);
           }
+        }
+      }
+    }
 
-          span {
-            margin-left: mobile-vw(12px);
+    :global(.hs-fieldtype-textarea) {
+      width: 100%;
+      border-radius: mobile-vw(8px);
+      position: relative;
+      font-family: var(--font-mono);
+      line-height: 150%;
+      color: var(--color-black) !important;
+      min-height: mobile-vw(100px);
 
-            @media (--desktop) {
-              margin-left: desktop-vw(12px);
+      @media (--desktop) {
+        border-radius: desktop-vw(8px);
+        min-height: desktop-vw(100px);
+      }
+
+      textarea {
+        border: 2px solid var(--color-black);
+        padding: mobile-vw(10px);
+        margin-bottom: 0;
+
+        @media (--desktop) {
+          padding: desktop-vw(6px) desktop-vw(16px);
+        }
+      }
+    }
+
+    :global(.hs-fieldtype-checkbox) {
+      width: 100%;
+
+      div > ul {
+        color: var(--color-black);
+        display: flex;
+        flex-direction: column;
+        row-gap: mobile-vw(10px);
+
+        @media (--desktop) {
+          row-gap: desktop-vw(10px);
+        }
+
+        > li {
+          position: relative;
+
+          @media (--hover) {
+            &:hover {
+              input {
+                background-color: var(--color-green);
+                color: var(--color-white);
+              }
             }
           }
 
-          input {
+          > label {
+            display: flex;
+            align-items: center;
             position: relative;
-            width: mobile-vw(30px);
-            aspect-ratio: 1 / 1;
-            border: 2px solid var(--color-gray);
-            border-radius: mobile-vw(4px);
-            overflow: hidden;
-            flex-shrink: 0;
-            transition:
-              500ms background-color var(--ease-gleasing),
-              500ms color var(--ease-gleasing);
+            line-height: normal;
+            font-size: mobile-vw(14px);
 
             @media (--desktop) {
-              width: desktop-vw(30px);
-              border-radius: desktop-vw(4px);
+              font-size: desktop-vw(14px);
             }
 
-            &::after {
-              content: '✓';
-              position: absolute;
-              top: -5%;
-              left: 12%;
-              width: 100%;
-              height: 100%;
-              font-size: mobile-vw(20px);
+            span {
+              margin-left: mobile-vw(12px);
 
               @media (--desktop) {
-                font-size: desktop-vw(20px);
+                margin-left: desktop-vw(12px);
+              }
+            }
+
+            input {
+              position: relative;
+              width: mobile-vw(30px);
+              aspect-ratio: 1 / 1;
+              border: 2px solid var(--color-gray);
+              border-radius: mobile-vw(4px);
+              overflow: hidden;
+              flex-shrink: 0;
+              transition:
+                500ms background-color var(--ease-gleasing),
+                500ms color var(--ease-gleasing);
+
+              @media (--desktop) {
+                width: desktop-vw(30px);
+                border-radius: desktop-vw(4px);
+              }
+
+              &::after {
+                content: '✓';
+                position: absolute;
                 top: -5%;
                 left: 12%;
-              }
-            }
-          }
-        }
-      }
+                width: 100%;
+                height: 100%;
+                font-size: mobile-vw(20px);
 
-      input:checked {
-        background-color: var(--color-green);
-        color: var(--color-white);
-      }
-    }
-  }
-
-  :global(.hs-fieldtype-radio) {
-    width: 100%;
-
-    div > ul {
-      color: var(--color-black);
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      column-gap: mobile-vw(10px);
-
-      @media (--desktop) {
-        column-gap: desktop-vw(10px);
-      }
-
-      > li {
-        position: relative;
-
-        @media (--hover) {
-          &:hover {
-            input {
-              &::after {
-                opacity: 1;
+                @media (--desktop) {
+                  font-size: desktop-vw(20px);
+                  top: -5%;
+                  left: 12%;
+                }
               }
             }
           }
         }
 
-        > label {
-          display: flex;
-          align-items: center;
-          position: relative;
-          line-height: normal;
-          font-size: mobile-vw(14px);
-
-          @media (--desktop) {
-            font-size: desktop-vw(14px);
-          }
-
-          span {
-            margin-left: mobile-vw(12px);
-
-            @media (--desktop) {
-              margin-left: desktop-vw(12px);
-            }
-          }
-
-          input {
-            position: relative;
-            width: mobile-vw(40px);
-            aspect-ratio: 1 / 1;
-            background-color: var(--color-white);
-            border: 2px solid var(--color-gray);
-            border-radius: 100%;
-            overflow: hidden;
-            flex-shrink: 0;
-
-            @media (--desktop) {
-              width: desktop-vw(40px);
-            }
-
-            &::after {
-              content: '';
-              position: absolute;
-              top: 0;
-              left: 0;
-              width: 100%;
-              height: 100%;
-              border-radius: 100%;
-              background-color: var(--color-green);
-              transform: scale(0.75);
-              opacity: 0;
-              transition: 500ms opacity var(--ease-gleasing);
-            }
-          }
-        }
-      }
-
-      input:checked {
-        &::after {
-          opacity: 1;
+        input:checked {
+          background-color: var(--color-green);
+          color: var(--color-white);
         }
       }
     }
-  }
 
-  :global(.hs-fieldtype-booleancheckbox) {
-    width: 100%;
+    :global(.hs-fieldtype-radio) {
+      width: 100%;
 
-    div > ul {
-      color: var(--color-black);
-
-      > li {
-        position: relative;
-
-        @media (--hover) {
-          &:hover {
-            input {
-              &::after {
-                opacity: 1;
-              }
-            }
-          }
-        }
-
-        > label {
-          display: flex;
-          align-items: center;
-          position: relative;
-          line-height: normal;
-          font-size: mobile-vw(14px);
-
-          @media (--desktop) {
-            font-size: desktop-vw(14px);
-          }
-
-          span {
-            margin-left: mobile-vw(12px);
-
-            @media (--desktop) {
-              margin-left: desktop-vw(12px);
-            }
-          }
-
-          input {
-            position: relative;
-            width: mobile-vw(74px);
-            aspect-ratio: 2 / 1;
-            border: 2px solid var(--color-gray);
-            overflow: hidden;
-            flex-shrink: 0;
-            border-radius: mobile-vw(32px);
-
-            @media (--desktop) {
-              width: desktop-vw(104px);
-              border-radius: desktop-vw(32px);
-            }
-
-            &::after {
-              content: '';
-              position: absolute;
-              top: 50%;
-              transform: translate(15%, -50%);
-              left: 0;
-              aspect-ratio: 1 / 1;
-              border-radius: 100%;
-              background-color: var(--color-gray);
-              width: mobile-vw(24px);
-              transition: 500ms transform var(--ease-gleasing);
-
-              @media (--desktop) {
-                width: desktop-vw(36px);
-              }
-            }
-          }
-        }
-      }
-
-      input:checked {
-        background-color: var(--color-green);
-
-        &::after {
-          background-color: var(--color-white);
-          transform: translate(175%, -50%);
-
-          @media (--desktop) {
-            transform: translate(160%, -50%);
-          }
-        }
-      }
-    }
-  }
-
-  :global(.hs_error_rollup) {
-    margin-bottom: desktop-vw(15px) !important;
-    color: red !important;
-
-    @media (--desktop) {
-      text-align: center;
-      font-size: desktop-vw(16px);
-    }
-  }
-
-  :global(.hs-form-field) {
-    position: relative;
-    width: 100%;
-    font-family: var(--font-mono);
-    line-height: 150%;
-    color: var(--color-black) !important;
-    margin-bottom: mobile-vw(45px);
-
-    @media (--desktop) {
-      margin-bottom: desktop-vw(25px);
-    }
-
-    > label {
-      position: relative;
-      color: var(--color-black);
-      top: mobile-vw(-5px);
-
-      @media (--desktop) {
-        font-size: desktop-vw(14px);
-        top: desktop-vw(-5px);
-      }
-    }
-
-    legend {
-      display: none !important;
-    }
-
-    &:has([role='alert']) {
-      input {
-        border: 2px solid red;
-      }
-
-      > ul {
-        position: absolute;
-        bottom: mobile-vw(-20px);
-        left: 0;
-        width: 100%;
-        color: red;
+      div > ul {
+        color: var(--color-black);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        column-gap: mobile-vw(10px);
 
         @media (--desktop) {
-          bottom: desktop-vw(-25px);
+          column-gap: desktop-vw(10px);
         }
 
-        li {
-          display: flex;
-          align-items: flex-end;
-          height: desktop-vw(20px);
-        }
-
-        label {
+        > li {
           position: relative;
-          font-size: mobile-vw(10px) !important;
 
-          @media (--desktop) {
-            font-size: desktop-vw(10px) !important;
+          @media (--hover) {
+            &:hover {
+              input {
+                &::after {
+                  opacity: 1;
+                }
+              }
+            }
+          }
+
+          > label {
+            display: flex;
+            align-items: center;
+            position: relative;
+            line-height: normal;
+            font-size: mobile-vw(14px);
+
+            @media (--desktop) {
+              font-size: desktop-vw(14px);
+            }
+
+            span {
+              margin-left: mobile-vw(12px);
+
+              @media (--desktop) {
+                margin-left: desktop-vw(12px);
+              }
+            }
+
+            input {
+              position: relative;
+              width: mobile-vw(40px);
+              aspect-ratio: 1 / 1;
+              background-color: var(--color-white);
+              border: 2px solid var(--color-gray);
+              border-radius: 100%;
+              overflow: hidden;
+              flex-shrink: 0;
+
+              @media (--desktop) {
+                width: desktop-vw(40px);
+              }
+
+              &::after {
+                content: '';
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                border-radius: 100%;
+                background-color: var(--color-green);
+                transform: scale(0.75);
+                opacity: 0;
+                transition: 500ms opacity var(--ease-gleasing);
+              }
+            }
+          }
+        }
+
+        input:checked {
+          &::after {
+            opacity: 1;
           }
         }
       }
     }
+
+    :global(.hs-fieldtype-booleancheckbox) {
+      width: 100%;
+
+      div > ul {
+        color: var(--color-black);
+
+        > li {
+          position: relative;
+
+          @media (--hover) {
+            &:hover {
+              input {
+                &::after {
+                  opacity: 1;
+                }
+              }
+            }
+          }
+
+          > label {
+            display: flex;
+            align-items: center;
+            position: relative;
+            line-height: normal;
+            font-size: mobile-vw(14px);
+
+            @media (--desktop) {
+              font-size: desktop-vw(14px);
+            }
+
+            span {
+              margin-left: mobile-vw(12px);
+
+              @media (--desktop) {
+                margin-left: desktop-vw(12px);
+              }
+            }
+
+            input {
+              position: relative;
+              width: mobile-vw(74px);
+              aspect-ratio: 2 / 1;
+              border: 2px solid var(--color-gray);
+              overflow: hidden;
+              flex-shrink: 0;
+              border-radius: mobile-vw(32px);
+
+              @media (--desktop) {
+                width: desktop-vw(104px);
+                border-radius: desktop-vw(32px);
+              }
+
+              &::after {
+                content: '';
+                position: absolute;
+                top: 50%;
+                transform: translate(15%, -50%);
+                left: 0;
+                aspect-ratio: 1 / 1;
+                border-radius: 100%;
+                background-color: var(--color-gray);
+                width: mobile-vw(24px);
+                transition: 500ms transform var(--ease-gleasing);
+
+                @media (--desktop) {
+                  width: desktop-vw(36px);
+                }
+              }
+            }
+          }
+        }
+
+        input:checked {
+          background-color: var(--color-green);
+
+          &::after {
+            background-color: var(--color-white);
+            transform: translate(175%, -50%);
+
+            @media (--desktop) {
+              transform: translate(160%, -50%);
+            }
+          }
+        }
+      }
+    }
+
+    :global(.hs_error_rollup) {
+      margin-bottom: desktop-vw(15px) !important;
+      color: red !important;
+
+      @media (--desktop) {
+        text-align: center;
+        font-size: desktop-vw(16px);
+      }
+    }
+
+    :global(.hs-form-field) {
+      position: relative;
+      width: 100%;
+      font-family: var(--font-mono);
+      line-height: 150%;
+      color: var(--color-black) !important;
+      margin-bottom: mobile-vw(45px);
+
+      @media (--desktop) {
+        margin-bottom: desktop-vw(25px);
+      }
+
+      > label {
+        position: relative;
+        color: var(--color-black);
+        top: mobile-vw(-5px);
+
+        @media (--desktop) {
+          font-size: desktop-vw(14px);
+          top: desktop-vw(-5px);
+        }
+      }
+
+      legend {
+        display: none !important;
+      }
+
+      &:has([role='alert']) {
+        input {
+          border: 2px solid red;
+        }
+
+        > ul {
+          position: absolute;
+          bottom: mobile-vw(-20px);
+          left: 0;
+          width: 100%;
+          color: red;
+
+          @media (--desktop) {
+            bottom: desktop-vw(-25px);
+          }
+
+          li {
+            display: flex;
+            align-items: flex-end;
+            height: desktop-vw(20px);
+          }
+
+          label {
+            position: relative;
+            font-size: mobile-vw(10px) !important;
+
+            @media (--desktop) {
+              font-size: desktop-vw(10px) !important;
+            }
+          }
+        }
+      }
+    }
+
+    .custom-form {
+      display: flex;
+      flex-direction: column;
+      max-width: 100%;
+    }
   }
 
-  .custom-form {
+  .submit {
+    cursor: pointer;
     display: flex;
-    flex-direction: column;
-    max-width: 100%;
-  }
-}
+    justify-content: center;
+    height: fit-content;
+    margin: 0 auto;
+    background-color: var(--color-black);
+    color: var(--color-white) !important;
+    border: none !important;
+    text-transform: uppercase;
+    font-weight: 600;
+    font-family: var(--font-mono);
+    border-radius: mobile-vw(10px);
+    width: mobile-vw(233px);
+    padding: mobile-vw(26px) mobile-vw(36px);
 
-.submit {
-  cursor: pointer;
-  display: flex;
-  justify-content: center;
-  height: fit-content;
-  margin: 0 auto;
-  background-color: var(--color-black);
-  color: var(--color-white) !important;
-  border: none !important;
-  text-transform: uppercase;
-  font-weight: 600;
-  font-family: var(--font-mono);
-  border-radius: mobile-vw(10px);
-  width: mobile-vw(233px);
-  padding: mobile-vw(26px) mobile-vw(36px);
-
-  @media (--desktop) {
-    width: desktop-vw(233px);
-    padding: desktop-vw(26px) desktop-vw(36px);
-    border-radius: desktop-vw(10px);
-    font-size: desktop-vw(16px);
+    @media (--desktop) {
+      width: desktop-vw(233px);
+      padding: desktop-vw(26px) desktop-vw(36px);
+      border-radius: desktop-vw(10px);
+      font-size: desktop-vw(16px);
+    }
   }
 }

--- a/lib/styles/css/index.css
+++ b/lib/styles/css/index.css
@@ -1,11 +1,16 @@
 /* INDEX CSS FILE - Barrel file for importing all the css files */
 /*
  * Explicit layer order (lowest to highest priority): `base` loses to
- * `utilities`, and both lose to any unlayered CSS — Tailwind utility classes
- * must override the browser reset, and a CSS Module rule must override both.
- * Layer order is fixed by this declaration, independent of import order.
+ * `components`, which loses to `utilities`, and all three lose to any
+ * unlayered CSS. Tailwind utility classes must override the browser reset and
+ * a component's own CSS Module (wrapped in `@layer components`, see AGENTS.md
+ * § Styling split) so a consumer's `className` wins; a consumer's unlayered
+ * CSS Module rule overrides everything. Layer order is fixed by this
+ * declaration, independent of import order. `components` must be named here
+ * because no global stylesheet has a block in it: without this line the first
+ * component module to load would create the layer after `utilities`.
  */
-@layer base, utilities;
+@layer base, components, utilities;
 
 @import 'tailwindcss/utilities.css' layer(utilities);
 @import './reset.css' layer(base);

--- a/lib/styles/scripts/utility-layering.test.ts
+++ b/lib/styles/scripts/utility-layering.test.ts
@@ -1,6 +1,14 @@
 /**
- * Guards the three-tier cascade contract: CSS Module > Tailwind utility >
- * browser reset.
+ * Guards the cascade contract: consumer CSS Module > Tailwind utility >
+ * component CSS Module > browser reset.
+ *
+ * A component that exposes `className` wraps its own module in
+ * `@layer components` so a consumer's Tailwind utility can override it (see
+ * AGENTS.md § Styling split). That layer has no block in any global
+ * stylesheet, so `index.css` must NAME it in the order declaration: without
+ * `components` there, the first component module to load would create the
+ * layer after `utilities` and invert the rule. The second describe block
+ * below checks the declaration; the last one checks every component module.
  *
  * `@import 'tailwindcss/utilities.css'` alone (no full `@import
  * 'tailwindcss'`, no `layer()` modifier) compiles every utility — Tailwind's
@@ -9,8 +17,8 @@
  * `all: unset` rule and any unlayered CSS Module. Whoever loads last (or has
  * the higher specificity) wins, which is unpredictable across chunks.
  *
- * The fix needs TWO layers, in a specific declared order, not just one:
- *   @layer base, utilities;
+ * The fix needs the layers in a specific declared order, not just one:
+ *   @layer base, components, utilities;
  *   @import 'tailwindcss/utilities.css' layer(utilities);
  *   @import './reset.css' layer(base);
  *
@@ -38,8 +46,9 @@
  * when someone reverts the fix.
  *
  * On failure: someone reverted the layer setup in `lib/styles/css/index.css`.
- * Put the `@layer base, utilities;` declaration and both `layer(...)` import
- * modifiers back.
+ * Put the `@layer base, components, utilities;` declaration and both
+ * `layer(...)` import modifiers back. If the component-module test fails, wrap
+ * that module in `@layer components { ... }`.
  *
  * Run with: bun test lib/styles/scripts/utility-layering.test.ts
  */
@@ -84,9 +93,9 @@ async function compile() {
 }
 
 describe('cascade layer order (source)', () => {
-  it("declares '@layer base, utilities;' with base first — base must be the lower-priority layer", async () => {
+  it("declares '@layer base, components, utilities;' in that order — each later layer beats the one before", async () => {
     const source = await Bun.file(indexCssPath).text()
-    expect(source).toMatch(/@layer\s+base\s*,\s*utilities\s*;/)
+    expect(source).toMatch(/@layer\s+base\s*,\s*components\s*,\s*utilities\s*;/)
   })
 
   it("imports reset.css with the 'base' layer modifier", async () => {
@@ -155,10 +164,11 @@ describe('cascade layer order (compiled output)', () => {
     expect(insideUtilities).toBe(false)
   })
 
-  it('only two named layers exist — nothing accidentally landed in a third', async () => {
+  it('only base and utilities have blocks in the global stylesheet — components is declared but stays empty here', async () => {
     const css = await compile()
     // `@layer properties` is Tailwind's own internal @property-fallback
-    // layer — expected and unrelated to this contract.
+    // layer — expected and unrelated to this contract. `components` is named
+    // in the order declaration but only component modules put rules in it.
     const namedLayerBlocks = (
       css.match(/@layer\s+([a-z]+)\s*\{/gi) ?? []
     ).filter((block) => !block.includes('properties'))
@@ -167,5 +177,31 @@ describe('cascade layer order (compiled output)', () => {
       .map((block) => block.match(/@layer\s+([a-z]+)/i)?.[1])
       .sort((a, b) => (a ?? '').localeCompare(b ?? ''))
     expect(names).toEqual(['base', 'utilities'])
+  })
+})
+
+describe('component modules are layered', () => {
+  it("every module beside a component that merges `className` is wrapped in '@layer components' (or 'utilities')", async () => {
+    // A component that does `cn(s.x, className)` promises the consumer's
+    // className wins. That only holds when the module is layered below
+    // `utilities`; an unlayered module rule beats every utility regardless
+    // of what cn() outputs. `image.module.css` layers into `utilities` on
+    // purpose (Tailwind `object-*` beats it by specificity), so either
+    // layer name satisfies the rule.
+    const glob = new Bun.Glob('{components,lib}/**/*.tsx')
+    const offenders: string[] = []
+    for await (const tsxPath of glob.scan({ cwd: repoRoot })) {
+      const tsx = await Bun.file(join(repoRoot, tsxPath)).text()
+      if (!/\bcn\([^)]*\bclassName\b/.test(tsx)) continue
+      const moduleImport = tsx.match(/from\s+'\.\/([\w-]+\.module\.css)'/)
+      if (!moduleImport?.[1]) continue
+      const modulePath = join(tsxPath, '..', moduleImport[1])
+      const css = await Bun.file(join(repoRoot, modulePath)).text()
+      const body = css.replace(/\/\*[\s\S]*?\*\//g, '').trim()
+      if (!/^@layer\s+(components|utilities)\s*\{/.test(body)) {
+        offenders.push(modulePath)
+      }
+    }
+    expect(offenders).toEqual([])
   })
 })

--- a/lib/webgl/components/canvas/webgl.module.css
+++ b/lib/webgl/components/canvas/webgl.module.css
@@ -1,12 +1,14 @@
-.webgl {
-  position: fixed;
-  inset: 0;
-  max-height: 100vh;
-  max-width: 100vw;
-  pointer-events: none;
+@layer components {
+  .webgl {
+    position: fixed;
+    inset: 0;
+    max-height: 100vh;
+    max-width: 100vw;
+    pointer-events: none;
 
-  canvas {
-    width: 100% !important;
-    height: 100% !important;
+    canvas {
+      width: 100% !important;
+      height: 100% !important;
+    }
   }
 }


### PR DESCRIPTION
## What this does

When a page passes a Tailwind class to a component's `className`, that class now reliably overrides the component's own styling. Before this, the component's CSS module won regardless, because unlayered CSS beats any Tailwind utility and no class-merging library can change that.

Stacked on #440 (it builds on the wrapper module introduced there).

## Summary

Review order: `lib/styles/css/index.css` and `AGENTS.md` first for the rule, then `lib/styles/scripts/utility-layering.test.ts` for the enforcement; the 18 module files are the same one-line wrap each.

- Every CSS module beside a component that does `cn(s.x, className)` is wrapped in `@layer components { ... }`. State, variant, and media rules inside are untouched.
- `index.css` declares `@layer base, components, utilities;`. The `components` layer has no block in any global stylesheet, so without naming it there the first component module to load created it after `utilities` and inverted the rule. Verified in the production build: the first stylesheet now emits `@layer components;` between `base` and `utilities`.
- `image.module.css` keeps its deliberate `utilities` layer for `object-fit`; its `.block` rule moves into `components`.
- New test: the declaration must name the three layers in order, and every className-merging component's module must open with `@layer components` or `@layer utilities`.
- AGENTS.md § Styling split records the precedence (consumer module, consumer utility, component module, reset) and why the starter does not carry `tailwind-merge`: the conflicts here are module versus utility, which layers decide.

## Test plan

- [ ] `bun run check` passes (683 tests)
- [ ] `bun run build`, then in the first CSS chunk linked from `.next/server/app/index.html` confirm `@layer components;` appears between `@layer base{` and `@layer utilities{`
- [ ] Render `<Wrapper className="flex-row">` on a page and confirm the main element's computed `flex-direction` is `row`
- [ ] Open the homepage and the `/ai` route: tabs, dialogs, toasts, and form fields look unchanged