### PR TITLE
test: export cookies from the next/headers mock

### DIFF
--- a/lib/utils/form-action.test.ts
+++ b/lib/utils/form-action.test.ts
@@ -17,8 +17,12 @@ import { describe, expect, mock, test } from 'bun:test'
 
 let turnstileCalls = 0
 
+// `mock.module` replaces next/headers for every later test file in the same
+// process, so it must export everything the code under test anywhere imports.
+// Shopify cart actions import `cookies`; a missing export fails at import time.
 void mock.module('next/headers', () => ({
   headers: async () => new Headers({ 'x-forwarded-for': '203.0.113.7' }),
+  cookies: async () => new Map<string, { value: string }>(),
 }))
 
 void mock.module('@/lib/integrations/turnstile', () => ({


### PR DESCRIPTION
## What this does

Plain `bun test` (serial) passes again. Before, it failed with `Export named 'cookies' not found in module next/headers` because the form-action test's `mock.module('next/headers')` replaces the module for every later test file in the process but only exported `headers`. The Shopify cart actions import `cookies`, so any test that reaches them after form-action failed at import time.

CI runs `bun test --parallel`, which isolates files, so it never saw this.

## Test plan

- [x] `bun test` serial: 695 tests, 0 fail
- [x] `bun run check`: green